### PR TITLE
Update rate-limit docs with new custom policy example

### DIFF
--- a/docs/policies/rate-limit.md
+++ b/docs/policies/rate-limit.md
@@ -78,20 +78,29 @@ requests, every 1 minute for each unique IP address.
 ## Using a custom function
 
 You can create a rate-limit bucket based on any property of a request using a
-custom function that returns a string (that is the identified used by the
-limiting system).
+custom function that returns a `CustomRateLimitPolicyOptions` object (which provides the identifier used by the limiting system).
 
-This example would create a unique rate-limiting function based on the `customerId`
-parameter in routes (note it’s important that a policy like this is applied to a
-route that has a `/:customerId` parameter).
+The `CustomRateLimitPolicyOptions` object can be used to override the `timeWindowMinutes` & `requestsAllowed` options.
+
+This example would create a unique rate-limiting function based on the `customerId` parameter in routes (note it’s important that a policy like this is applied to a route that has a `/:customerId` parameter).
 
 ```ts
 //module - ./modules/rate-limiter.ts
 
-import { ZuploRequest } from "@zuplo/runtime"
+import { CustomRateLimitPolicyOptions, ZuploRequest } from "@zuplo/runtime";
 
-export function rateLimitKey(request:ZuploRequest) {
-  return request.params.customerId;
+export function rateLimitKey(
+  request: ZuploRequest
+): CustomRateLimitPolicyOptions {
+  if (request.params.customerId === "43567890") {
+    // Override timeWindowMinutes & requestsAllowed
+    return {
+      key: request.params.customerId,
+      requestsAllowed: 100,
+      timeWindowMinutes: 1,
+    };
+  }
+  return { key: request.params.customerId };
 }
 ```
 


### PR DESCRIPTION
Updates the docs with new custom policy changes that allow overriding default options.