### PR TITLE
ZUP-1822: Add doc for using Zuplo CLI

### DIFF
--- a/docs/guides/custom-ci-cd.md
+++ b/docs/guides/custom-ci-cd.md
@@ -1,0 +1,93 @@
+---
+title: Setting up a Custom CI/CD Pipeline
+sidebar_label: Custom CI/CD
+---
+
+Zuplo provides the Zuplo deployer, a GitHub app that can be used to automatically deploy your APIs from your GitHub repository to the Zuplo platform. However, we realized that sometimes you might not be using GitHub as your version control system. Or, that you might want to exercise more control over your CI/CD pipeline. For these cases, we provide a CLI that can be used to deploy your APIs to the Zuplo platform.
+
+## Getting Started
+
+1. Contact [support](mailto:support@zuplo.com) to enable API keys for your Zuplo project.
+1. Navigate to [dev.zuplo.com/docs](https://dev.zuplo.com/docs) and click on "Sign in" on the top right corner.
+1. Navigate to [authentication](https://dev.zuplo.com/docs/v1/#authentication) and generate some API keys. You will use these keys to authenticate with the Zuplo CLI.
+1. Write some tests for your API. We provide a rich set of test helpers and utils based on BDD. You can see examples of tests at [samples](https://github.com/zuplo/zup-cli-example-project/tree/main/tests).
+
+## Setting up a custom workflow with GitHub Actions
+
+The full example is available at https://github.com/zuplo/zup-cli-example-project
+
+1. Create a workflow file. You can use the following to help you get started:
+
+```yaml title="/.github/workflows/main.yaml"
+name: Zuplo CI on Pull Request
+
+on:
+  pull_request:
+
+jobs:
+  run-zup-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      # This explicitly tells action to use the latest version of Zuplo from the public NPM registry
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+          registry-url: "https://registry.npmjs.com"
+          scope: "@zuplo"
+
+      - name: NPM Install
+        run: npm install
+
+      # shell: bash is required so that pipefail is set.
+      # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+      # This way if the deploy fails, we fail before piping to tee.
+      - name: Zup Deploy
+        shell: bash
+        env:
+          ZUPLO_API_KEY: ${{ secrets.ZUPLO_API_KEY }}
+        run: |
+          npx @zuplo/cli deploy --apiKey "$ZUPLO_API_KEY" | tee ./DEPLOYMENT_STDOUT
+
+      - name: Zup Test
+        shell: bash
+        run: |
+          npx @zuplo/cli test --endpoint $(cat ./DEPLOYMENT_STDOUT |  sed -E 's/Deployed to (.*)/\1/')
+```
+
+2. Create a secret for your GitHub Action and be sure to set `ZUPLO_API_KEY` to the API key you generated in the previous step.
+
+## Setting up a custom workflow with Bitbucket Pipelines
+
+The full example is available at https://bitbucket.org/zuplocom/zup-cli-example-project/
+
+```yaml title="/bitbucket-pipelines.yml"
+image: node:18
+
+pipelines:
+  pull-requests:
+    "**": #this runs as default for any branch not elsewhere defined
+      - step:
+          name: NPM Install
+          script:
+            - npm install
+      - step:
+          name: Zup Deploy
+          # set -o pipefail
+          # This way if the deploy fails, we fail before piping to tee.
+          script:
+            - set -o pipefail
+            - npx @zuplo/cli deploy --apiKey "$ZUPLO_API_KEY" | tee
+              ./DEPLOYMENT_STDOUT
+          artifacts:
+            - DEPLOYMENT_STDOUT
+      - step:
+          name: Zup Test
+          script:
+            - npx @zuplo/cli test --endpoint $(cat ./DEPLOYMENT_STDOUT |  sed -E
+              's/Deployed to (.*)/\1/')
+```
+
+2. Create a secret repository variable for your BitBucket Pipelines and be sure to set `ZUPLO_API_KEY` to the API key you generated in the previous step.

--- a/docs/guides/custom-ci-cd.md
+++ b/docs/guides/custom-ci-cd.md
@@ -19,6 +19,12 @@ The API Key generated is specific for each project. If you have multiple project
 
 4. Write some tests for your API. We provide a rich set of test helpers and utils based on BDD. You can see examples of tests at [samples](https://github.com/zuplo/zup-cli-example-project/tree/main/tests).
 
+:::tip
+
+Your test files need to be under the `tests` folder and end with `.test.ts` to be picked up by the Zuplo CLI.
+
+:::
+
 ## Setting up a custom workflow with GitHub Actions
 
 The full example is available at https://github.com/zuplo/zup-cli-example-project

--- a/docs/guides/custom-ci-cd.md
+++ b/docs/guides/custom-ci-cd.md
@@ -8,9 +8,16 @@ Zuplo provides the Zuplo deployer, a GitHub app that can be used to automaticall
 ## Getting Started
 
 1. Contact [support](mailto:support@zuplo.com) to enable API keys for your Zuplo project.
-1. Navigate to [dev.zuplo.com/docs](https://dev.zuplo.com/docs) and click on "Sign in" on the top right corner.
-1. Navigate to [authentication](https://dev.zuplo.com/docs/v1/#authentication) and generate some API keys. You will use these keys to authenticate with the Zuplo CLI.
-1. Write some tests for your API. We provide a rich set of test helpers and utils based on BDD. You can see examples of tests at [samples](https://github.com/zuplo/zup-cli-example-project/tree/main/tests).
+2. Navigate to [dev.zuplo.com/docs](https://dev.zuplo.com/docs) and click on "Sign in" on the top right corner.
+3. Navigate to [authentication](https://dev.zuplo.com/docs/v1/#authentication) and generate some API keys. You will use these keys to authenticate with the Zuplo CLI.
+
+:::tip
+
+The API Key generated is specific for each project. If you have multiple projects, you will need to generate a new API key for each project. Contact [support](mailto:support@zuplo.com) to enable API keys for every Zuplo project that you want to use the CLI with.
+
+:::
+
+4. Write some tests for your API. We provide a rich set of test helpers and utils based on BDD. You can see examples of tests at [samples](https://github.com/zuplo/zup-cli-example-project/tree/main/tests).
 
 ## Setting up a custom workflow with GitHub Actions
 

--- a/docs/guides/testing-deployments.md
+++ b/docs/guides/testing-deployments.md
@@ -2,11 +2,16 @@
 title: Testing Deployments
 ---
 
-Using the Zuplo GitHub integration, tests can be run after a deployment and used to block pull requests from being merged. This can help ensure that changes to your Zuplo gateway won't break your production environment.
+:::tip
+
+These instructions assume that you are using custom GitHub Action workflow, in conjunction with the Zuplo deployer. If you prefer setting up your own CI/CD for more fine-grained control, please take a look at [running your own CI/CD](../guides/custom-ci-cd.md).
+:::
+
+Using the Zuplo GitHub integration, tests can be run after a deployment with the Zuplo deployer and used to block pull requests from being merged. This can help ensure that changes to your Zuplo gateway won't break your production environment.
 
 The Zuplo deployer sets [Deployments](https://docs.github.com/en/rest/deployments/deployments) and [Deployment Statuses](https://docs.github.com/en/rest/deployments/statuses) for any push to a GitHub branch.
 
-A simple GitHub Action that runs `mocha` after the deployment is successful. Notice how the property `github.event.deployment_status.environment_url` is set to the `API_URL` environment variable. This is one way you can pass the URL where the preview environment is deployed into your tests.
+Here is a simple GitHub Action that uses the Zuplo CLI to run the tests after the deployment is successful. Notice how the property `github.event.deployment_status.environment_url` is set to the `API_URL` environment variable. This is one way you can pass the URL where the preview environment is deployed into your tests.
 
 ```yaml title="/.github/workflows/main.yaml"
 name: Main
@@ -26,28 +31,25 @@ jobs:
 
       - name: Run Tests
         # Useful properties 'environment', 'state', and 'environment_url'
-        run: API_URL=${{ toJson(github.event.deployment_status.environment_url) }} npx mocha -y -- "./tests/**/*.spec.mjs"
+        run: API_URL=${{ toJson(github.event.deployment_status.environment_url) }} npx @zuplo/cli test --endpoint $API_URL
 ```
 
-Using Node.js 18, it is very easy to write tests that make requests to your API using `fetch` and then validate expectations with `assert`.
+Using Node.js 18 and the Zuplo CLI, it is very easy to write tests that make requests to your API using `fetch` and then validate expectations with `expect` from [chai](https://www.chaijs.com/api/bdd/).
 
 ```js title="/tests/my-test.spec.mjs"
-import assert from "assert";
-
-const apiUrl = process.env.API_URL;
-if (!apiUrl) {
-  console.error("ERROR: API_URL environmental variable is not set");
-  process.exit(1);
-}
+import { describe, it, TestHelper } from "@zuplo/test";
+import { expect } from "chai";
 
 describe("API", () => {
   it("should have a body", async () => {
-    const response = await fetch(`${apiUrl}`);
+    const response = await fetch(TestHelper.TEST_URL);
     const result = await response.text();
-    assert.equal(result, JSON.stringify("What zup?"));
+    expect(result).to.equal(JSON.stringify("What zup?"));
   });
 });
 ```
+
+You can find more sample tests [here](https://github.com/zuplo/zup-cli-example-project/tree/main/tests).
 
 [GitHub Branch protection](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches) can be set in order to enforce policies on when a Pull Request can be merged. The example below sets the "Zuplo Deployment" and "Test API Gateway" as required status that must pass.
 

--- a/docs/guides/testing-deployments.md
+++ b/docs/guides/testing-deployments.md
@@ -51,6 +51,12 @@ describe("API", () => {
 
 You can find more sample tests [here](https://github.com/zuplo/zup-cli-example-project/tree/main/tests).
 
+::: tip
+
+Your test files need to be under the `tests` folder and end with `.test.ts` to be picked up by the Zuplo CLI.
+
+:::
+
 [GitHub Branch protection](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches) can be set in order to enforce policies on when a Pull Request can be merged. The example below sets the "Zuplo Deployment" and "Test API Gateway" as required status that must pass.
 
 ![](https://cdn.zuplo.com/assets/a1d7c322-125d-4d80-add0-fbfb65ccfea1.png)

--- a/sidebars.js
+++ b/sidebars.js
@@ -42,6 +42,7 @@ const sidebars = {
         "guides/oauth-client-management",
         "guides/multiple-auth-policies",
         "guides/testing-deployments",
+        "guides/custom-ci-cd",
         "guides/custom-cors-policy",
         "guides/advanced-path-matching",
       ],


### PR DESCRIPTION
I decided to emphasize the use of the CLI for CI/CD.
In the future, when the CLI can support local dev as well, we can change the structure/messaging. But, for now, it's simpler to keep it focused on what the customer needs: custom CI/CD.