### PR TITLE
Remove the bucketName to be injected by default

### DIFF
--- a/policies/api-key-inbound/schema.json
+++ b/policies/api-key-inbound/schema.json
@@ -54,7 +54,6 @@
           "export": "ApiKeyInboundPolicy",
           "module": "$import(@zuplo/runtime)",
           "options": {
-            "bucketName": "CONTACT_SUPPORT_FOR_YOUR_BUCKET_NAME",
             "allowUnauthenticatedRequests": false
           }
         }


### PR DESCRIPTION
Do not add the bucketName in the example so we can inject without noise for the user