### PR TITLE
Update dev portal docs

### DIFF
--- a/docs/articles/dev-portal-adding-pages.md
+++ b/docs/articles/dev-portal-adding-pages.md
@@ -2,25 +2,36 @@
 title: Custom Pages
 ---
 
-You can add custom pages to your developer portal to provide more documentation to your API users. You are in full control of the content and how users will navigate to it.
+You can add custom pages to your developer portal to provide more documentation
+to your API users. You are in full control of the content and how users will
+navigate to it.
 
 ## Writing Your First Custom Page
 
-Within your project in the Zuplo Portal, you will notice a `Docs` directory, with an `index.md` and `sidebar.json` file. `index.md` is a custom page we created to get you started.
+Within your project in the Zuplo Portal, you will notice a `Docs` directory,
+with an `index.md` and `sidebar.json` file. `index.md` is a custom page we
+created to get you started.
 
 ![Docs Folder](../../static/media/developer-portal/adding-pages/docs-folder.png)
 
-Navigate to `index.md`, and make some changes to the markdown. If you are unfamiliar with Markdown, check out [this guide](https://www.markdownguide.org/) to get started. You can also create a new docs page via the new file button.
+Navigate to `index.md`, and make some changes to the markdown. If you are
+unfamiliar with Markdown, check out [this guide](https://www.markdownguide.org/)
+to get started. You can also create a new docs page via the new file button.
 
 ## Previewing Your Changes
 
-You can preview what your page will look like in the developer portal by clicking the 'Markdown Preview' tab above the editor.
+You can preview what your page will look like in the developer portal by
+clicking the 'Markdown Preview' tab above the editor.
 
 ![Markdown Preview](../../static/media/developer-portal/adding-pages/style-preview.png)
 
 ## Configuring the Sidebar
 
-Next, you will configure where your new page will be displayed in the developer portal's sidebar navigation. Open [`sidebar.json`](./dev-portal-configuring-sidebar.md). All pages you wish to display should go under the `docs` folder in the order you want them displayed in the navigation. A typical sidebar entry consists of the following:
+Next, you will configure where your new page will be displayed in the developer
+portal's sidebar navigation. Open
+[`sidebar.json`](./dev-portal-configuring-sidebar.md). All pages you wish to
+display should go under the `docs` folder in the order you want them displayed
+in the navigation. A typical sidebar entry consists of the following:
 
 ```json
 {
@@ -30,23 +41,28 @@ Next, you will configure where your new page will be displayed in the developer 
 }
 ```
 
-Open your developer portal after saving your changes, and you should see your new page in the sidebar!
+Open your developer portal after saving your changes, and you should see your
+new page in the sidebar!
 
-## Optional: Select a Version
+## Optional: Select an OpenAPI Spec
 
-Your page may only apply to a certain version of your API. You can configure which versions of your API the custom page will be displayed through the `versions` property.
+Your page may only apply to a certain part of your API. You can configure which
+OpenAPI spec the custom page will be displayed on through the `specs` property.
 
 ```json
 {
   "type": "doc",
   "id": "index",
   "label": "Index",
-  "versions": ["versionOneName"]
+  "specs": ["billing-api"]
 }
 ```
 
-By default, a custom page will display on all versions of your API unless the `versions` field is specified.
+By default, a custom page will display on all OpenAPI specs unless the `specs`
+field is specified. Learn more
+[here](./dev-portal-configuring-sidebar.md#customizing-individual-openapi-specs).
 
 ## Congratulations, you have added a custom page!
 
-You can add as many custom pages as you like to create an awesome developer experience.
+You can add as many custom pages as you like to create an awesome developer
+experience.

--- a/docs/articles/dev-portal-configuration.md
+++ b/docs/articles/dev-portal-configuration.md
@@ -2,6 +2,20 @@
 title: OpenAPI Specifications
 ---
 
-Zuplo natively uses the OpenAPI specification to power both the gateway routing and Developer Portal documentation.
+Zuplo natively uses the OpenAPI specification to power both the gateway routing
+and Developer Portal documentation. Your OpenAPI file (contained within your
+project's `config` folder and ending in `.oas.json`) is used to automatically
+generate stripe-quality API Reference documentation. By enriching your OpenAPI
+file with additional properties, you directly enable more content show up in the
+Developer Portal.
 
-Read more about OpenAPI and all the possibilities [here](https://oai.github.io/Documentation/specification.html). The more content that is added to the Open API the more will show up in the developer portal.
+Read more about OpenAPI and all the possibilities
+[here](https://oai.github.io/Documentation/specification).
+
+## Handling Multiple OpenAPI Files
+
+Your project may utilize multiple OpenAPI files to power your gateway. The
+Developer Portal is equipped to handle this - allowing users to navigate between
+documentation for each OpenAPI spec. You can even
+[customize the content](./dev-portal-configuring-sidebar.md#customizing-individual-openapi-specs)
+displayed on each OpenAPI spec.

--- a/docs/articles/dev-portal-configuring-sidebar.md
+++ b/docs/articles/dev-portal-configuring-sidebar.md
@@ -2,38 +2,62 @@
 title: Sidebar Configuration
 ---
 
-You can configure your Developer Portal Sidebar through the `sidebar.json` file. This file allows you to determine which pages get displayed, their labels, and their order.
+You can configure your Developer Portal Sidebar through the `sidebar.json` file.
+This file allows you to determine which pages get displayed, their labels, and
+their order.
 
 ## Configuring sidebar.json
 
-`sidebar.json` consists of items of different `types` either `doc`, `category`, or `api-ref`. The file is configured in a very similar way to [Docusaurus' sidebar.js](https://docusaurus.io/docs/sidebar/items#sidebar-item-category). The `docs` array must contain all the items of the sidebar.
+`sidebar.json` consists of items of different `types` either `doc`, `category`,
+or `api-ref`. The file is configured in a very similar way to
+[Docusaurus' sidebar.js](https://docusaurus.io/docs/sidebar/items#sidebar-item-category).
+The `docs` array must contain all the items of the sidebar.
 
-### Versioning
+### Customizing Individual OpenAPI Specs
 
-A `versions` array is added as an optional property on `doc` and `category` items. Not including the `versions` array will automatically include the item in all versions of your API. The entries to `versions` must match the version names found in your `routes.json`. For `category` types, adding a version to an `item` will result in the page only displaying if it is also found in the `category` item's version array.
+A `specs` array is added as an optional property on `doc` and `category` items.
+Not including the `specs` array will automatically include the item in all of
+your OpenAPI specs. The entries to `specs` must match the `specId` of the
+OpenAPI file (portion of filename preceding `.oas.json`) found in your project's
+`config` folder. For `category` types, adding `specs` to an `item` will result
+in the page only displaying if it is also found in the `category` item's `specs`
+array.
 
 ### Sidebar Labels
 
-A `label` property is found on most items. It determines what text appears in the sidebar navigation. The label can also be provided via [frontmatter](https://jekyllrb.com/docs/front-matter/) using the `sidebar_label` property.
+A `label` property is found on most items. It determines what text appears in
+the sidebar navigation. The label can also be provided via
+[frontmatter](https://jekyllrb.com/docs/front-matter/) using the `sidebar_label`
+property.
 
 :::note
 
-If a label is provided on both the `sidebar.json` item and the markdown `frontmatter`, the `frontmatter` will take precedence.
+If a label is provided on both the `sidebar.json` item and the markdown
+`frontmatter`, the `frontmatter` will take precedence.
 
 :::
 
 ## Adding an api-ref
 
-An `api-ref` item dictates the position of your API Reference docs in the sidebar. You can also relabel the top-level label (the default is API Reference). The contents of your API Reference are automatically generated from your `routes.json`.
+An `api-ref` item dictates the position of your API Reference docs in the
+sidebar. You can also relabel the top-level label (the default is API
+Reference). The contents of your API Reference are automatically generated from
+your `routes.json`.
 
 ```typescript
 interface APIDocConfig {
   type: "api-ref";
   label: string;
+  /**
+   * defaultSpec allows you to specify the spec navigated to upon loading the
+   * developer portal
+   */
+  defaultSpec: string;
 }
 ```
 
-When you create a project, we will automatically populate the following `api-ref` item in your `sidebar.json`:
+When you create a project, we will automatically populate the following
+`api-ref` item in your `sidebar.json`:
 
 ```json
 {
@@ -50,14 +74,19 @@ A `doc` is a single page that contains content from a markdown file.
 interface DocConfig {
   type: "doc";
   /**
-   * ID Must be unique across all pages and map to a markdown filename in /docs
+   * ID Must be unique across all pages and map to a markdown filename in /docs (excluding the extension)
    */
   id: string;
   /**
    * Label Must be unique across doc and category items within this array only
    */
   label: string;
-  versions?: VersionsConfig;
+  specs?: string[];
+  /**
+   * When set to true, this page will be navigated to upon loading the developer
+   * portal
+   */
+  defaultPage?: boolean;
 } | string // shorthand
 ```
 
@@ -73,7 +102,8 @@ Here's an example:
 
 ### Shorthand
 
-You can also add a `doc` item via shorthand notation in which you only include the `id` field in the `sidebar.json`.
+You can also add a `doc` item via shorthand notation in which you only include
+the `id` field in the `sidebar.json`.
 
 ```json
 {
@@ -81,17 +111,20 @@ You can also add a `doc` item via shorthand notation in which you only include t
 }
 ```
 
-Note that you will be unable to provide versioning, but you can [provide a label](#sidebar-labels) in the `frontmatter`
+Note that you will be unable to specify `specs` or `defaultPage`, but you can
+[provide a label](#sidebar-labels) in the `frontmatter`
 
 ## Adding a category
 
-A `category` is a directory of `doc` items. Within your Sidebar, the `items` entries will appear nested under the `label` of the `category` item. Each entry in `items` must contain a unique `id` and `label` within the `items` array.
+A `category` is a directory of `doc` items. Within your Sidebar, the `items`
+entries will appear nested under the `label` of the `category` item. Each entry
+in `items` must contain a unique `id` and `label` within the `items` array.
 
 ```typescript
 interface CategoryConfig {
   type: "category";
   label: string;
-  versions?: VersionsConfig;
+  versions?: string[];
   link?: DocLink | string;
   /**
    * @minItems 1
@@ -109,7 +142,9 @@ interface DocLink {
 }
 ```
 
-A `category` item can act like a `doc` if a `link` property is provided. When clicked the user will be navigated to the page referenced in the `link`. If no `link` is provided, then the `category` will not be clickable.
+A `category` item can act like a `doc` if a `link` property is provided. When
+clicked the user will be navigated to the page referenced in the `link`. If no
+`link` is provided, then the `category` will not be clickable.
 
 Example:
 
@@ -119,7 +154,7 @@ Example:
     {
       "type": "category",
       "label": "Dog Breeds",
-      "versions": ["v1", "v2"],
+      "specs": ["routes-v1", "routes-v2"],
       "link": {
         "type": "doc",
         "id": "dog-breeds"
@@ -130,7 +165,7 @@ Example:
           "type": "doc",
           "label": "Poodle",
           "id": "poodle",
-          "versions": ["v2"]
+          "specs": ["routes-v2"]
         }
       ]
     }


### PR DESCRIPTION
## Summary
Updating the dev portal docs to reflect the deprecation of `versions`, introduction of `specs`, `defaultPage` and `defaultSpec`