### PR TITLE
Remove references to routes.json

### DIFF
--- a/docs/articles/archiving-requests-to-storage.md
+++ b/docs/articles/archiving-requests-to-storage.md
@@ -91,24 +91,22 @@ export default async function (
 }
 ```
 
-Finally, you need to configure your routes.json file to include the policy,
+Finally, you need to configure your policies.json file to include the policy,
 example below:
 
 ```json
-"policies": [
-    {
-      "name": "request-archive-policy",
-      "policyType": "code-policy",
-      "handler": {
-        "export": "default",
-        "module": "$import(./modules/archive-request-policy)",
-        "options": {
-					"blobCreateSas" : "$env(BLOB_CREATE_SAS)",
-					"blobContainerPath" : "$env(BLOB_CONTAINER_PATH)"
-				}
-      }
+{
+  "name": "request-archive-policy",
+  "policyType": "code-policy",
+  "handler": {
+    "export": "default",
+    "module": "$import(./modules/archive-request-policy)",
+    "options": {
+      "blobCreateSas": "$env(BLOB_CREATE_SAS)",
+      "blobContainerPath": "$env(BLOB_CONTAINER_PATH)"
     }
-  ]
+  }
+}
 ```
 
 Don't forget to reference the `file-archive-policy` in the policies.inbound

--- a/docs/articles/custom-cors-policy.md
+++ b/docs/articles/custom-cors-policy.md
@@ -2,31 +2,32 @@
 title: Custom CORS policies
 ---
 
-There are two built-in CORS policies called `none` and `anything-goes`. The former disallows any cross-origin access while the latter allows any cross-origin access (and is discouraged for production use cases). To correctly support CORS we recommend creating and using a custom CORS policy.
+There are two built-in CORS policies called `none` and `anything-goes`. The
+former disallows any cross-origin access while the latter allows any
+cross-origin access (and is discouraged for production use cases). To correctly
+support CORS we recommend creating and using a custom CORS policy.
 
 ## CORS Policy
 
-Custom policies are created in the routes.json file alongside the routes, policies and versions properties:
+Custom CORS policies are created in the policies.json file alongside regular
+policies:
 
 ```json
 {
-  "routes": [], //...
   "policies": [], //...
-  "versions": [], //...
   "corsPolicies": [] // custom CORS policies go here
 }
 ```
 
-A CORS policy consists of a name and set of CORS headers to be returned
-for cross-origin requests (both the simple type and pre-flight request).
+A CORS policy consists of a name and set of CORS headers to be returned for
+cross-origin requests (both the simple type and pre-flight request).
 
-:::warning
-Make sure to not have a trailing `/` on your allowedOrigins. e.g. `https://exampple.com` is valid, `https://example.com/` will not work.
-:::
+:::warning Make sure to not have a trailing `/` on your allowedOrigins. e.g.
+`https://example.com` is valid, `https://example.com/` will not work. :::
 
 ```json
 {
-  //... rest of routes.json file
+  //... rest of policies.json file
   "corsPolicies": [
     {
       "name": "custom-cors",
@@ -43,38 +44,35 @@ Make sure to not have a trailing `/` on your allowedOrigins. e.g. `https://examp
 
 :::note
 
-You can specify a list of supported domains. Zuplo will ensure the pre-flight request is compatible with browsers by filtering the list to match the incoming origin, provided it is in your list of origins.
+You can specify a list of supported domains. Zuplo will ensure the pre-flight
+request is compatible with browsers by filtering the list to match the incoming
+origin, provided it is in your list of origins.
 
 :::
 
-You can then reference your custom CORS policy in your route by specifying the name of your CORS policy on your route, (or choosing it in the route designer UI).
+You can then reference your custom CORS policy in your route by specifying the
+name of your CORS policy on your route, (or choosing it in the route designer
+UI).
 
 ```json
-{
-  "routes": [
-    {
-      "methods": [
-        "GET"
-      ],
-      "corsPolicy": "custom-cors",
-      "path": "/",
-      "summary": "New Route",
-      "description": "Lorem ipsum...",
-      "version": "none",
-
-      "handler": {
-        "export": "urlRewriteHandler",
-        "module": "$import(@zuplo/runtime)",
-        "options": {
-          "rewritePattern": "https://welcome.zuplo.io/",
-          "forwardSearch": true
+"paths": {
+  "/redirect-test": {
+    "get": {
+      "x-zuplo-route": {
+        "corsPolicy": "custom-cors",
+        "handler": {
+          "module": "$import(@zuplo/runtime)",
+          "export": "redirectHandler",
+          "options": {
+            "location": "/docs"
+          }
         }
       },
-      "policies": {
-        "inbound": []
-      }
-      //...
-
+      ...
+    }
+  }
+}
 ```
 
-For more information on CORS, check out the MDN documentation: [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
+For more information on CORS, check out the MDN documentation:
+[Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)

--- a/docs/articles/dev-portal-configuring-sidebar.md
+++ b/docs/articles/dev-portal-configuring-sidebar.md
@@ -42,7 +42,7 @@ If a label is provided on both the `sidebar.json` item and the markdown
 An `api-ref` item dictates the position of your API Reference docs in the
 sidebar. You can also relabel the top-level label (the default is API
 Reference). The contents of your API Reference are automatically generated from
-your `routes.json`.
+your `routes.oas.json`.
 
 ```typescript
 interface APIDocConfig {

--- a/docs/articles/dev-portal-setup.md
+++ b/docs/articles/dev-portal-setup.md
@@ -3,9 +3,14 @@ title: Developer Portal Setup
 sidebar_label: Setup
 ---
 
-Customization of your developer portal can be done in either the Zuplo Portal or by editing source files using your preferred editor. Before you start customizing the developer portal, its a good idea to understand the structure and files that are used to generate the site.
+Customization of your developer portal can be done in either the Zuplo Portal or
+by editing source files using your preferred editor. Before you start
+customizing the developer portal, its a good idea to understand the structure
+and files that are used to generate the site.
 
-Every Zuplo project includes the following directories and files that are used to generate the developer portal. Note, files that are not directly part of this tutorial have been deliberately left out.
+Every Zuplo project includes the following directories and files that are used
+to generate the developer portal. Note, files that are not directly part of this
+tutorial have been deliberately left out.
 
 ```txt
 my-project/
@@ -19,14 +24,25 @@ my-project/
     └── theme.css
 ```
 
-- **config/routes.oas.json** - This is your Open API specification that contains the full structure of your API project. [Documentation](./dev-portal-configuration.md)
-- **docs/index.md** - Markdown files are used to include additional documentation in your developer portal. By default an `index.md` file is created. [Documentation](./dev-portal-adding-pages.md)
-- **docs/sidebar.json** - This file contains the configuration for your sidebar and menus on the developer portal. [Documentation](./dev-portal-configuring-sidebar.md)
-- **docs/theme.css** - The developer portal theme can be customized with CSS variables (or even custom CSS) in order to match your branding. [Documentation](./dev-portal-theme.md)
-- **docs/dev-portal.json** - This is the primary configuration for your developer portal with customization for the favicon, authentication settings, etc. [Documentation](./dev-portal-json.md)
+- **config/routes.oas.json** - This is your Open API specification that contains
+  the full structure of your API project.
+  [Documentation](./dev-portal-configuration.md)
+- **docs/index.md** - Markdown files are used to include additional
+  documentation in your developer portal. By default an `index.md` file is
+  created. [Documentation](./dev-portal-adding-pages.md)
+- **docs/sidebar.json** - This file contains the configuration for your sidebar
+  and menus on the developer portal.
+  [Documentation](./dev-portal-configuring-sidebar.md)
+- **docs/theme.css** - The developer portal theme can be customized with CSS
+  variables (or even custom CSS) in order to match your branding.
+  [Documentation](./dev-portal-theme.md)
+- **docs/dev-portal.json** - This is the primary configuration for your
+  developer portal with customization for the favicon, authentication settings,
+  etc. [Documentation](./dev-portal-json.md)
 
 :::caution
 
-At the time of writing this document, the `docs/dev-portal.json` file is not shown in the Zuplo Portal. Instead it can be accessed through **Settings** > **Developer Portal**. This will be addressed shortly.
+At the time of writing this document, the `docs/dev-portal.json` file is
+currently under the `config` folder. This will be addressed shortly.
 
 :::

--- a/docs/articles/step-1-setup-basic-gateway.md
+++ b/docs/articles/step-1-setup-basic-gateway.md
@@ -2,19 +2,25 @@
 title: Step 1 - Setup a Basic Gateway
 ---
 
-In this tutorial we'll setup a simple gateway. We'll use a demo API at [todos.zuplo.io](https://todos.zuplo.io/todos) that acts as a todolist API.
+In this tutorial we'll setup a simple gateway. We'll use a demo API at
+[todos.zuplo.io](https://todos.zuplo.io/todos) that acts as a todolist API.
 
-This demo API is protected by an API key (sometimes called a shared secret) that must be provided in an `api-key` header. Good news - given this is a demo API - the key is provided in the unauthenticated error message.
+This demo API is protected by an API key (sometimes called a shared secret) that
+must be provided in an `api-key` header. Good news - given this is a demo API -
+the key is provided in the unauthenticated error message.
 
-To get started, sign in to [portal.zuplo.com](https://portal.zuplo.com) and create a free account. Create a new **empty** project. Then...
+To get started, sign in to [portal.zuplo.com](https://portal.zuplo.com) and
+create a free account. Create a new **empty** project. Then...
 
 ## 1/ Add a route
 
-Inside your new project, choose the `routes.oas.json` file and click **Add Route**.
+Inside your new project, choose the `routes.oas.json` file and click **Add
+Route**.
 
 ![ADd Route](https://cdn.zuplo.com/assets/8cfa5b7b-6ead-4dd0-9339-dbcdc21b6299.png)
 
-Using the Route Designer, let's configure our first route to handle the `GET /todos` route.
+Using the Route Designer, let's configure our first route to handle the
+`GET /todos` route.
 
 - Summary: `Get all todos`
 - Method: `GET`
@@ -23,9 +29,11 @@ Using the Route Designer, let's configure our first route to handle the `GET /to
 
 ![Get all todos](https://cdn.zuplo.com/assets/f2bcc7ad-027f-4f5e-8764-c802079dacdb.png)
 
-Save your changes (you can click the disk icon next to `routes.json` or press CMD+S).
+Save your changes (you can click the disk icon next to `routes.oas.json` or
+press CMD+S).
 
-You can quickly test this route by clicking the **Test** button next to the **Path** field and clicking the URL in the dialog that opens.
+You can quickly test this route by clicking the **Test** button next to the
+**Path** field and clicking the URL in the dialog that opens.
 
 ![Test](https://cdn.zuplo.com/assets/cd094b3c-efbe-4c2b-995c-60ce0302704a.png)
 
@@ -43,11 +51,14 @@ You should receive a 401 Unauthorized that says something similar to
 }
 ```
 
-This is expected because you have not provided the required `api-key` header. Copy the required `api-key` value from that error message to your clipboard (e.g. `4f0aeaf7-d17f-4b2b-9b71-5177bd194759`).
+This is expected because you have not provided the required `api-key` header.
+Copy the required `api-key` value from that error message to your clipboard
+(e.g. `4f0aeaf7-d17f-4b2b-9b71-5177bd194759`).
 
 ## 2/ Set the secret header
 
-Open the policies section in your route and click **Add Policy** to the request pipeline.
+Open the policies section in your route and click **Add Policy** to the request
+pipeline.
 
 ![Add policy](https://cdn.zuplo.com/assets/8eab7f3e-3d24-411d-8a4f-7cde11fe6ccf.png)
 
@@ -55,23 +66,30 @@ Find the **Add or Set Request Header**
 
 ![Find policy](https://cdn.zuplo.com/assets/67937c50-598d-433a-945a-17787841f036.png)
 
-Configure the policy JSON to set header name to `api-key` and the value to `$env(API_KEY)`. This tells the policy to read the value from our secure vault used for [Environment Variables](/docs/articles/environment-variables.md).
+Configure the policy JSON to set header name to `api-key` and the value to
+`$env(API_KEY)`. This tells the policy to read the value from our secure vault
+used for [Environment Variables](/docs/articles/environment-variables.md).
 
 ![Policy Configuration](https://cdn.zuplo.com/assets/e29a3c79-aeee-48e9-8c40-d1131c10f33a.png)
 
-Save you changes to `routes.json`.
+Save you changes to `routes.oas.json`.
 
-Head over to the Environment Variables screen in settings and click **Add new variable**.
+Head over to the Environment Variables screen in settings and click **Add new
+variable**.
 
 ![Add new Environment Variable](https://cdn.zuplo.com/assets/e9119f6a-e3e0-4d71-8739-62155e23d2da.png)
 
-Set the name to `API_KEY` and select **is Secret** (the demo API key is not really secret but if you use an API key to access your backend, that _is_ an important secret).
+Set the name to `API_KEY` and select **is Secret** (the demo API key is not
+really secret but if you use an API key to access your backend, that _is_ an
+important secret).
 
 ![New environment variable](https://cdn.zuplo.com/assets/70fdd686-641a-4792-8a55-dafb952c0178.png)
 
 ## 3/ Test your API
 
-Go back to your route in the Route Designer and click the **Test** button next to the **Path** field. Open the URL in the browser and you should see a list of todoitems.
+Go back to your route in the Route Designer and click the **Test** button next
+to the **Path** field. Open the URL in the browser and you should see a list of
+todoitems.
 
 ```
 [
@@ -97,16 +115,22 @@ Congratulations, your gateway is working 👏👏👏
 
 ## 4/ BONUS - put the base URL in an environment variable
 
-When working with Zuplo, you'll eventually want each [environment](/docs/articles/environments) to use a different backend (e.g. QA, staging, preview, production etc).
+When working with Zuplo, you'll eventually want each
+[environment](/docs/articles/environments) to use a different backend (e.g. QA,
+staging, preview, production etc).
 
-Change the **URL Forward** value to read the base URL from the [Environment Variables](/docs/articles/environment-variables) system by setting the value to `${env.BASE_URL}`.
+Change the **URL Forward** value to read the base URL from the
+[Environment Variables](/docs/articles/environment-variables) system by setting
+the value to `${env.BASE_URL}`.
 
 ![BASE_URL from Environment](https://cdn.zuplo.com/assets/b52a04bd-b4d2-4e70-88e7-b32b1a7cba7d.png)
 
-Add another Environment Variable called BASE_URL. This is typically not a secret, there's no need to hide this from your colleagues.
+Add another Environment Variable called BASE_URL. This is typically not a
+secret, there's no need to hide this from your colleagues.
 
 ![BASE_URL Env Variable](https://cdn.zuplo.com/assets/068841d1-6554-448b-a869-62aa4076c85d.png)
 
 Save all your changes and test your route again.
 
-**NEXT** Try [step 2 - add API key authentication to your API](./step-2-add-api-key-auth.md).
+**NEXT** Try
+[step 2 - add API key authentication to your API](./step-2-add-api-key-auth.md).

--- a/docs/handlers/aws-lambda.md
+++ b/docs/handlers/aws-lambda.md
@@ -25,15 +25,16 @@ Configure the properties for your AWS Lambda function.
 
 :::warning
 
-Don't add the AWS Secure Access Key directly in the `routes.json` file. Instead
-use environment variables like `$env(AWS_SECURE_ACCESS_KEY)`
+Don't add the AWS Secure Access Key directly in the `routes.oas.json` file.
+Instead use environment variables like `$env(AWS_SECURE_ACCESS_KEY)`
 
 :::
 
-## Setup via Routes.json
+## Setup via routes.oas.json
 
-The AWS Lambda handler can be setup by editing the `routes.json` file directly
-by configuring the handler property on any route.
+The AWS Lambda handler can be setup by editing the `routes.oas.json` file
+directly by configuring the `handler` property on any route's `x-zuplo-route`
+property.
 
 ```json
 {

--- a/docs/handlers/redirect.md
+++ b/docs/handlers/redirect.md
@@ -3,30 +3,47 @@ title: Redirect Handler
 sidebar_label: Redirect
 ---
 
-The Redirect Handler sends a redirect HTTP response to the client. You can specify whether this is 301 (Permanent) or 302 (Temporary), or specify a custom status in routes.json.
+The Redirect Handler sends a redirect HTTP response to the client. You can
+specify whether this is 301 (Permanent) or 302 (Temporary), or specify a custom
+status in routes.oas.json.
 
 ## Setup via Portal
 
-The Redirect Handler can be added to any route using the Route Designer. Open the **Route Designer** by navigating to the <CodeEditorTabIcon /> **Code Editor** tab then click **Route Designer**. Inside any route, select **Redirect** from the **Request Handlers** drop-down.
+The Redirect Handler can be added to any route using the Route Designer. Open
+the **Route Designer** by navigating to the <CodeEditorTabIcon /> **Code
+Editor** tab then click **routes.oas.json**. Inside any route, select
+**Redirect** from the **Request Handlers** drop-down.
 
 In the text box enter the URL location for the redirect.
 
-## Setup in routes.json
+## Setup in routes.oas.json
 
-You can also configure the Redirect Handler directly in the **routes.json** file, e.g. as in the route below (which is redirecting requests at the root of your domain to your docs page at /docs).
+You can also configure the Redirect Handler directly in the **routes.oas.json**
+file, e.g. as in the route below (which is redirecting requests at the root of
+your domain to your docs page at /docs).
 
 ```json
-{
-  "path": "/",
-  "methods": ["GET"],
-  "handler": {
-    "module": "$import(@zuplo/runtime)",
-    "export": "redirectHandler",
-    "options": {
-      "location": "/docs"
+"paths": {
+  "/redirect-test": {
+    "x-zuplo-path": {
+      "pathMode": "open-api"
+    },
+    "get": {
+      "summary": "Testing rewrite handler",
+      "x-zuplo-route": {
+        "corsPolicy": "none",
+        "handler": {
+          "module": "$import(@zuplo/runtime)",
+          "export": "redirectHandler",
+          "options": {
+            "location": "/docs"
+          }
+        }
+      },
+      "policies": {
+        "inbound": []
+      }
     }
-  },
-  "version": "none",
-  "corsPolicy": "none"
+  }
 }
 ```

--- a/docs/handlers/url-forward.md
+++ b/docs/handlers/url-forward.md
@@ -3,21 +3,29 @@ title: URL Forward Handler
 sidebar_label: URL Forward
 ---
 
-The URL Forward handler can be used to proxy requests to a different API without writing any code. It simply appends the incoming `path` section of the URL onto the specified `baseUrl` property. For example:
+The URL Forward handler can be used to proxy requests to a different API without
+writing any code. It simply appends the incoming `path` section of the URL onto
+the specified `baseUrl` property. For example:
 
 If you have an incoming request with url
 
 `https://my-gateway.com/pizza/cheese/size/large`
 
-And you have a URL forward handler with a baseUrl of `https://my-backend.com/folder` - the gateway will make a request to
+And you have a URL forward handler with a baseUrl of
+`https://my-backend.com/folder` - the gateway will make a request to
 
-`https://my-backend.com/folder/pizza/cheese/size/large`. By default it will forward any search parameters.
+`https://my-backend.com/folder/pizza/cheese/size/large`. By default it will
+forward any search parameters.
 
 ## Setup via Portal
 
-The Forward Handler can be added to any route using the Route Designer. Open the **Route Designer** by navigating to the <CodeEditorTabIcon /> **Code Editor** tab then click **Route Designer**. Inside any route, select **URL Forward** from the **Request Handlers** drop-down.
+The Forward Handler can be added to any route using the Route Designer. Open the
+**Route Designer** by navigating to the <CodeEditorTabIcon /> **Files** tab then
+click **routes.oas.json**. Inside any route, select **URL Forward** from the
+**Request Handlers** drop-down.
 
-In the text box enter the URL to rewrite the request. Values can be mixed into the URL string using Javascript string interpolation syntax. For example:
+In the text box enter the URL to rewrite the request. Values can be mixed into
+the URL string using Javascript string interpolation syntax. For example:
 
 ```
 https://${env.BASE_HOST_NAME}/${method}/${params.productId}
@@ -25,22 +33,41 @@ https://${env.BASE_HOST_NAME}/${method}/${params.productId}
 
 The following objects are available for substitution:
 
-- `env` - the environment object, to access [Environment Variables](../articles/environment-variables.md)
-- `request: ZuploRequest` - the full [`ZuploRequest`](../articles/zuplo-request.md) object
-- `params: Record<string, string>` - The parameters of the route. For example, `params.productId` would be the value of `:productId` in a route.
-- `query: Record<string, string>` - The query parameters of the route. For example, `query.filterBy` would be the value of `?filterBy=VALUE`.
-- `headers: Headers` - the incoming request's [headers object](https://developer.mozilla.org/en-US/docs/Web/API/Headers)
+- `env` - the environment object, to access
+  [Environment Variables](../articles/environment-variables.md)
+- `request: ZuploRequest` - the full
+  [`ZuploRequest`](../articles/zuplo-request.md) object
+- `params: Record<string, string>` - The parameters of the route. For example,
+  `params.productId` would be the value of `:productId` in a route.
+- `query: Record<string, string>` - The query parameters of the route. For
+  example, `query.filterBy` would be the value of `?filterBy=VALUE`.
+- `headers: Headers` - the incoming request's
+  [headers object](https://developer.mozilla.org/en-US/docs/Web/API/Headers)
 - `url: string` - The full incoming request as a string
-- `host: string` - The [`host`](https://developer.mozilla.org/en-US/docs/Web/API/URL/host) portion of the incoming URL
-- `hostname: string` - The [`hostname`](https://developer.mozilla.org/en-US/docs/Web/API/URL/hostname) portion of the incoming URL
-- `pathname: string` - The [`pathname`](https://developer.mozilla.org/en-US/docs/Web/API/URL/pathname) portion of the incoming URL
-- `port: string` - The [`port`](https://developer.mozilla.org/en-US/docs/Web/API/URL/port) portion of the incoming URL
-- `search` - The [`search`](https://developer.mozilla.org/en-US/docs/Web/API/URL/search) portion of the incoming URL
+- `host: string` - The
+  [`host`](https://developer.mozilla.org/en-US/docs/Web/API/URL/host) portion of
+  the incoming URL
+- `hostname: string` - The
+  [`hostname`](https://developer.mozilla.org/en-US/docs/Web/API/URL/hostname)
+  portion of the incoming URL
+- `pathname: string` - The
+  [`pathname`](https://developer.mozilla.org/en-US/docs/Web/API/URL/pathname)
+  portion of the incoming URL
+- `port: string` - The
+  [`port`](https://developer.mozilla.org/en-US/docs/Web/API/URL/port) portion of
+  the incoming URL
+- `search` - The
+  [`search`](https://developer.mozilla.org/en-US/docs/Web/API/URL/search)
+  portion of the incoming URL
 
 Use the following methods to encode portions of the URL:
 
-- `encodeURIComponent`: The [`encodeURIComponent()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) function encodes a URI by replacing each instance of certain characters with escape sequences.
-- `e`: An alias to `encodeURIComponent` to help keep URLs more readable. Can be used like `${e(params.productId)}`
+- `encodeURIComponent`: The
+  [`encodeURIComponent()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent)
+  function encodes a URI by replacing each instance of certain characters with
+  escape sequences.
+- `e`: An alias to `encodeURIComponent` to help keep URLs more readable. Can be
+  used like `${e(params.productId)}`
 
 ### Example Values
 
@@ -60,40 +87,55 @@ A few examples of the values of various substitutions.
 - `${url}` - `"https://example.com:8080/v1/products/:productId?category=cars"`
 - `${env.BASE_URL}` - `"https://example.com"`
 
-## Setup via Routes.json
+## Setup via routes.oas.json
 
-The URL Forward handler can also be added manually to the **routes.json** file with the following route configuration.
+The URL Forward handler can also be added manually to the **routes.oas.json**
+file with the following route configuration.
 
 ```json
-{
-  "label": "Welcome",
-  "path": "/",
-  "methods": ["GET"],
-  "handler": {
-    "module": "$import(@zuplo/runtime)",
-    "export": "urlForwardHandler",
-    "options": {
-      "baseUrl": "${env.BASE_URL}"
+"paths": {
+  "/forward-test": {
+    "x-zuplo-path": {
+      "pathMode": "open-api"
+    },
+    "get": {
+      "summary": "Testing forward handler",
+      "x-zuplo-route": {
+        "corsPolicy": "none",
+        "handler": {
+          "export": "urlForwardHandler",
+          "module": "$import(@zuplo/runtime)",
+          "options": {
+            "baseUrl": "${env.BASE_URL}"
+          }
+        },
+        "policies": {
+          "inbound": []
+        }
+      }
     }
-  },
-  "corsPolicy": "anything-goes",
-  "version": "none",
-  "summary": "Proxy Welcome API",
-  "description": "This Route will proxy the welcome.zuplo.io api"
+  }
 }
 ```
 
 ## Options
 
-The URL Rewrite handler can be configured via `options` to support common use-cases.
+The URL Rewrite handler can be configured via `options` to support common
+use-cases.
 
 - `baseUrl` - the base URL the incoming pathname will be appended to.
-- `forwardSearch` - The query string will be automatically included in the rewritten url.
-- `followRedirects` - Determines if redirects should be followed when fetching the rewrite url . When set to `false` or not specified, redirects will not be followed - the status and `location` header will be returned as received.
+- `forwardSearch` - The query string will be automatically included in the
+  rewritten url.
+- `followRedirects` - Determines if redirects should be followed when fetching
+  the rewrite url . When set to `false` or not specified, redirects will not be
+  followed - the status and `location` header will be returned as received.
 
 ## Different Backends per Environment
 
-It's common to want a different backend for your production, staging and preview environments. This can be easily achieved by using [environment variables](../articles/environment-variables.md) to specify the origin of the backend.
+It's common to want a different backend for your production, staging and preview
+environments. This can be easily achieved by using
+[environment variables](../articles/environment-variables.md) to specify the
+origin of the backend.
 
 For example,
 
@@ -101,7 +143,8 @@ For example,
 ${env.BASE_PATH}
 ```
 
-A url rewrite like this will combine the `BASE_PATH` environment variable, say `https://example.com`
+A url rewrite like this will combine the `BASE_PATH` environment variable, say
+`https://example.com`
 
 ```
 https://example.com/foo/bar

--- a/docs/handlers/url-rewrite.md
+++ b/docs/handlers/url-rewrite.md
@@ -3,15 +3,24 @@ title: URL Rewrite Handler
 sidebar_label: URL Rewrite
 ---
 
-The URL Rewrite handler can be used to proxy and rewrite requests to a different API without writing any code. The handler allows mapping request data and parameters to a URL on another host. You can also combine the URL rewrite handler with policies such as the [Change Method Inbound](../policies/change-method-inbound.md) policy to modify virtually any aspect of your request.
+The URL Rewrite handler can be used to proxy and rewrite requests to a different
+API without writing any code. The handler allows mapping request data and
+parameters to a URL on another host. You can also combine the URL rewrite
+handler with policies such as the
+[Change Method Inbound](../policies/change-method-inbound.md) policy to modify
+virtually any aspect of your request.
 
 ## Setup via Portal
 
-The Rewrite Handler can be added to any route using the Route Designer. Open the **Route Designer** by navigating to the <CodeEditorTabIcon /> **Code Editor** tab then click **Route Designer**. Inside any route, select **URL Rewrite** from the **Request Handlers** drop-down.
+The Rewrite Handler can be added to any route using the Route Designer. Open the
+**Route Designer** by navigating to the <CodeEditorTabIcon /> **Files** tab then
+click **routes.oas.json**. Inside any route, select **URL Rewrite** from the
+**Request Handlers** drop-down.
 
 ![Url Rewrite Handler selection](../../static/media/url-rewrite-handler-selection.png)
 
-In the text box enter the URL to rewrite the request. Values can be mixed into the URL string using Javascript string interpolation syntax. For example:
+In the text box enter the URL to rewrite the request. Values can be mixed into
+the URL string using Javascript string interpolation syntax. For example:
 
 ```
 https://echo.zuplo.io/${method}/${params.productId}
@@ -19,23 +28,43 @@ https://echo.zuplo.io/${method}/${params.productId}
 
 The following objects are available for substitution:
 
-- `env` - the environment object, to access [Environment Variables](../articles/environment-variables.md)
-- `request: ZuploRequest` - the full [`ZuploRequest`](../articles/zuplo-request.md) object
-- `context: ZuploContext` - the [`ZuploContext`](../articles/zuplo-context.md) object without functions.
-- `params: Record<string, string>` - The parameters of the route. For example, `params.productId` would be the value of `:productId` in a route.
-- `query: Record<string, string>` - The query parameters of the route. For example, `query.filterBy` would be the value of `?filterBy=VALUE`.
-- `headers: Headers` - the incoming request's [headers object](https://developer.mozilla.org/en-US/docs/Web/API/Headers)
+- `env` - the environment object, to access
+  [Environment Variables](../articles/environment-variables.md)
+- `request: ZuploRequest` - the full
+  [`ZuploRequest`](../articles/zuplo-request.md) object
+- `context: ZuploContext` - the [`ZuploContext`](../articles/zuplo-context.md)
+  object without functions.
+- `params: Record<string, string>` - The parameters of the route. For example,
+  `params.productId` would be the value of `:productId` in a route.
+- `query: Record<string, string>` - The query parameters of the route. For
+  example, `query.filterBy` would be the value of `?filterBy=VALUE`.
+- `headers: Headers` - the incoming request's
+  [headers object](https://developer.mozilla.org/en-US/docs/Web/API/Headers)
 - `url: string` - The full incoming request as a string
-- `host: string` - The [`host`](https://developer.mozilla.org/en-US/docs/Web/API/URL/host) portion of the incoming URL
-- `hostname: string` - The [`hostname`](https://developer.mozilla.org/en-US/docs/Web/API/URL/hostname) portion of the incoming URL
-- `pathname: string` - The [`pathname`](https://developer.mozilla.org/en-US/docs/Web/API/URL/pathname) portion of the incoming URL
-- `port: string` - The [`port`](https://developer.mozilla.org/en-US/docs/Web/API/URL/port) portion of the incoming URL
-- `search` - The [`search`](https://developer.mozilla.org/en-US/docs/Web/API/URL/search) portion of the incoming URL
+- `host: string` - The
+  [`host`](https://developer.mozilla.org/en-US/docs/Web/API/URL/host) portion of
+  the incoming URL
+- `hostname: string` - The
+  [`hostname`](https://developer.mozilla.org/en-US/docs/Web/API/URL/hostname)
+  portion of the incoming URL
+- `pathname: string` - The
+  [`pathname`](https://developer.mozilla.org/en-US/docs/Web/API/URL/pathname)
+  portion of the incoming URL
+- `port: string` - The
+  [`port`](https://developer.mozilla.org/en-US/docs/Web/API/URL/port) portion of
+  the incoming URL
+- `search` - The
+  [`search`](https://developer.mozilla.org/en-US/docs/Web/API/URL/search)
+  portion of the incoming URL
 
 Use the following methods to encode portions of the URL:
 
-- `encodeURIComponent`: The [`encodeURIComponent()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) function encodes a URI by replacing each instance of certain characters with escape sequences.
-- `e`: An alias to `encodeURIComponent` to help keep URLs more readable. Can be used like `${e(params.productId)}`
+- `encodeURIComponent`: The
+  [`encodeURIComponent()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent)
+  function encodes a URI by replacing each instance of certain characters with
+  escape sequences.
+- `e`: An alias to `encodeURIComponent` to help keep URLs more readable. Can be
+  used like `${e(params.productId)}`
 
 ### Example Values
 
@@ -55,39 +84,56 @@ A few examples of the values of various substitutions.
 - `${url}` - `"https://example.com:8080/v1/products/:productId?category=cars"`
 - `${env.BASE_URL}` - `"https://example.com"`
 
-## Setup via Routes.json
+## Setup via routes.oas.json
 
-The URL Rewrite handler can also be added manually to the **routes.json** file with the following route configuration.
+The URL Rewrite handler can also be added manually to the **routes.oas.json**
+file with the following route configuration.
 
 ```json
-{
-  "label": "Welcome",
-  "path": "/",
-  "methods": ["GET"],
-  "handler": {
-    "module": "$import(@zuplo/runtime)",
-    "export": "urlRewriteHandler",
-    "options": {
-      "rewritePattern": "https://welcome.zuplo.io"
+"paths": {
+  "/rewrite-test": {
+    "summary": "Proxy Welcome API",
+    "description": "This Route will proxy the welcome.zuplo.io api",
+    "x-zuplo-path": {
+      "pathMode": "open-api"
+    },
+    "get": {
+      "summary": "Testing rewrite handler",
+      "x-zuplo-route": {
+        "corsPolicy": "none",
+        "handler": {
+          "export": "urlRewriteHandler",
+          "module": "$import(@zuplo/runtime)",
+          "options": {
+            "rewritePattern": "https://welcome.zuplo.io"
+          }
+        },
+        "policies": {
+          "inbound": []
+        }
+      }
     }
-  },
-  "corsPolicy": "anything-goes",
-  "version": "none",
-  "summary": "Proxy Welcome API",
-  "description": "This Route will proxy the welcome.zuplo.io api"
+  }
 }
 ```
 
 ## Options
 
-The URL Rewrite handler can be configured via `options` to support common use-cases.
+The URL Rewrite handler can be configured via `options` to support common
+use-cases.
 
-- `forwardSearch` - The query string will be automatically included in the rewritten url.
-- `followRedirects` - Determines if redirects should be followed when fetching the rewrite url . When set to `false` or not specified, redirects will not be followed - the status and `location` header will be returned as received.
+- `forwardSearch` - The query string will be automatically included in the
+  rewritten url.
+- `followRedirects` - Determines if redirects should be followed when fetching
+  the rewrite url . When set to `false` or not specified, redirects will not be
+  followed - the status and `location` header will be returned as received.
 
 ## Different Backends per Environment
 
-It's common to want a different backend for your production, staging and preview environments. This can be easily achieved by using [environment variables](../articles/environment-variables.md) to specify the origin of the backend.
+It's common to want a different backend for your production, staging and preview
+environments. This can be easily achieved by using
+[environment variables](../articles/environment-variables.md) to specify the
+origin of the backend.
 
 For example,
 
@@ -95,7 +141,9 @@ For example,
 ${env.BASE_PATH}${pathname}
 ```
 
-A url rewrite like this will combine the `BASE_PATH` environment variable, say `https://example.com` with the incoming path, e.g. `/foo/bar` to create a re-written URL:
+A url rewrite like this will combine the `BASE_PATH` environment variable, say
+`https://example.com` with the incoming path, e.g. `/foo/bar` to create a
+re-written URL:
 
 ```json
 https://example.com/foo/bar

--- a/policies/auth0-jwt-auth-inbound/doc.md
+++ b/policies/auth0-jwt-auth-inbound/doc.md
@@ -1,35 +1,54 @@
 ## Tutorial
 
-We will start with the hello-world sample you get when you create a new Zup. So your routes file should look like this:
+We will start by adding a route to your `routes.oas.json` file that will use the
+policy. You can paste the following into the file
 
 ```json
 {
-  "routes": [
-    {
-      "label": "What zup?",
-      "path": "hello-world",
-      "handler": {
-        "export": "default",
-        "module": "$import(./modules/hello-world)"
+  "openapi": "3.1.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "My Zuplo API"
+  },
+  "paths": {
+    "/hello-world": {
+      "x-zuplo-path": {
+        "pathMode": "open-api"
       },
-      "methods": ["GET", "POST"],
-      "corsPolicy": "anything-goes",
-      "version": "v1",
-      "policies": {
-        "inbound": []
+      "get": {
+        "summary": "Route 1",
+        "description": "",
+        "operationId": "b53744a5-a41c-468e-a47a-5ab85b0c5866",
+        "x-zuplo-route": {
+          "corsPolicy": "anything-goes",
+          "handler": {
+            "export": "default",
+            "module": "$import(./modules/hello-world)",
+            "options": {}
+          },
+          "policies": {
+            "inbound": []
+          }
+        }
+      },
+      "post": {
+        "summary": "Route 2",
+        "description": "",
+        "operationId": "b0fbbd59-cd35-407a-8fe1-469c4f3ab142",
+        "x-zuplo-route": {
+          "corsPolicy": "anything-goes",
+          "handler": {
+            "export": "default",
+            "module": "$import(./modules/hello-world)",
+            "options": {}
+          },
+          "policies": {
+            "inbound": []
+          }
+        }
       }
     }
-  ],
-  "versions": [
-    {
-      "name": "none",
-      "pathPrefix": ""
-    },
-    {
-      "name": "v1",
-      "pathPrefix": "v1.0/"
-    }
-  ]
+  }
 }
 ```
 
@@ -54,7 +73,8 @@ export default async function (request: ZuploRequest, context: ZuploContext) {
 
 You should already have a test setup in the test client, like this
 
-The next step is to enforce authentication on this API using Auth0 and JWT tokens.
+The next step is to enforce authentication on this API using Auth0 and JWT
+tokens.
 
 ## Setting up Auth0
 
@@ -75,18 +95,14 @@ Inside the settings for your new API, you should see a Test tab
 
 ![CleanShot 2021-11-29 at 16.30.40@2x.png](/media/guides/setup-jwt-auth-with-auth0/CleanShot_2021-11-29_at_16.30.402x.png)
 
-We'll need this cURL script shortly to get an access token to test against our API.
+We'll need this cURL script shortly to get an access token to test against our
+API.
 
 ## Configuring the Zuplo Policy
 
 Next, we will configure our Open ID JWT Policy - more documentation on this
-[here](./open-id-jwt-auth-inbound.md). Add a `policies` array to your routes.json as shown below.
-
-![CleanShot 2021-11-29 at 16.35.43@2x.png](/media/guides/setup-jwt-auth-with-auth0/CleanShot_2021-11-29_at_16.35.432x.png)
-
-> **Hint** - press _option+shift+F_ to automatically format your code, including JSON in the editor.
-
-Now add the following policy inside the `policies` array:
+[here](./open-id-jwt-auth-inbound.md). Add the policy to `policies` array to
+your policies.json.
 
 ```json
 {
@@ -105,14 +121,16 @@ Now add the following policy inside the `policies` array:
 }
 ```
 
-- The `audience` property in options should exactly match the `Identifier` we created in Auth0 earlier, so `https://zuplo-auth-sample/` in this case.
+- The `audience` property in options should exactly match the `Identifier` we
+  created in Auth0 earlier, so `https://zuplo-auth-sample/` in this case.
 - The `issuer` field will be the URL for your Auth0 tenant, e.g.
   `https://zuplo-demo.us.auth0.com/`.
 - The `jwkUrl` is the public URL of your JWK set.
 
 :::tip
 
-If you're not sure where to find the issuer or jwkUrl you can easily find it in the Node.JS QuickStart for your API as shown below.
+If you're not sure where to find the issuer or jwkUrl you can easily find it in
+the Node.JS QuickStart for your API as shown below.
 
 :::
 
@@ -120,9 +138,8 @@ If you're not sure where to find the issuer or jwkUrl you can easily find it in 
 
 ## Adding the policy to your route(s)
 
-Finally, we need to add this policy to our route as follows
-
-![CleanShot 2021-11-29 at 16.51.59@2x.png](/media/guides/setup-jwt-auth-with-auth0/CleanShot_2021-11-29_at_16.51.592x.png)
+Finally, we need to add this policy to our route by adding `auth-policy` to the
+`handler.policies.inbound` array property on each route.
 
 ## Testing the policy
 
@@ -132,11 +149,15 @@ should get a `401: Unauthorized` response from your API.
 ![CleanShot 2021-11-29 at 16.55.43@2x.png](/media/guides/setup-jwt-auth-with-auth0/CleanShot_2021-11-29_at_16.55.432x.png)
 
 Next, let's get a valid token using the cURL script from earlier in this
-tutorial. Copy the cURL script from the test tab and execute it in a terminal window:
+tutorial. Copy the cURL script from the test tab and execute it in a terminal
+window:
 
 ![CleanShot 2021-11-29 at 17.03.34@2x.png](/media/guides/setup-jwt-auth-with-auth0/CleanShot_2021-11-29_at_17.03.342x.png)
 
-Carefully extract the access_token only and copy it to the clipboard. Paste into a header in the test client called `authorization`. Note that the value of the header should be `Bearer <access_token>` replacing `<access_token>` with the token you got back from cURL.
+Carefully extract the access_token only and copy it to the clipboard. Paste into
+a header in the test client called `authorization`. Note that the value of the
+header should be `Bearer <access_token>` replacing `<access_token>` with the
+token you got back from cURL.
 
 ![CleanShot 2021-11-29 at 17.06.08@2x.png](/media/guides/setup-jwt-auth-with-auth0/CleanShot_2021-11-29_at_17.06.082x.png)
 
@@ -144,7 +165,8 @@ Carefully extract the access_token only and copy it to the clipboard. Paste into
 
 ## Accessing the user object
 
-Now let's update our script to explore the values inside the user object. Add the following line to the middle of your request handler:
+Now let's update our script to explore the values inside the user object. Add
+the following line to the middle of your request handler:
 
 ```tsx
 export default async function (request: ZuploRequest, context: ZuploContext) {
@@ -154,7 +176,8 @@ export default async function (request: ZuploRequest, context: ZuploContext) {
 }
 ```
 
-Execute the test again and you'll see the following JSON output in the **Request Logs** window:
+Execute the test again and you'll see the following JSON output in the **Request
+Logs** window:
 
 ```json
 {
@@ -189,7 +212,8 @@ Add two claims to your M2M tokens using the following code:
 
 ![CleanShot 2021-11-29 at 17.44.55@2x.png](/media/guides/setup-jwt-auth-with-auth0/CleanShot_2021-11-29_at_17.44.552x.png)
 
-And, critically, remember to click `Deploy`. Also, note that the claims MUST be URLs (again, they do not need to be live URLs, just valid in structure).
+And, critically, remember to click `Deploy`. Also, note that the claims MUST be
+URLs (again, they do not need to be live URLs, just valid in structure).
 
 ```ts
 exports.onExecuteCredentialsExchange = async (event, api) => {
@@ -206,7 +230,8 @@ exports.onExecuteCredentialsExchange = async (event, api) => {
 
 ## Re-test your API
 
-Get a fresh token using cURL (same approach as above, it's important to get a fresh token so that it contains these new claims).
+Get a fresh token using cURL (same approach as above, it's important to get a
+fresh token so that it contains these new claims).
 
 Paste the token into the test client and re-execute the API.
 

--- a/policies/rate-limit-inbound/doc.md
+++ b/policies/rate-limit-inbound/doc.md
@@ -1,17 +1,23 @@
 :::tip
 
-Note you can have multiple instances of rate-limiting policies to use in combination. You should apply the longest duration timeWindow first, in order to the shortest duration time window.
+Note you can have multiple instances of rate-limiting policies to use in
+combination. You should apply the longest duration timeWindow first, in order to
+the shortest duration time window.
 
 :::
 
 ## Using a custom function
 
 You can create a rate-limit bucket based on any property of a request using a
-custom function that returns a `CustomRateLimitDetails` object (which provides the identifier used by the limiting system).
+custom function that returns a `CustomRateLimitDetails` object (which provides
+the identifier used by the limiting system).
 
-The `CustomRateLimitDetails` object can be used to override the `timeWindowMinutes` & `requestsAllowed` options.
+The `CustomRateLimitDetails` object can be used to override the
+`timeWindowMinutes` & `requestsAllowed` options.
 
-This example would create a unique rate-limiting function based on the `customerId` parameter in routes (note it’s important that a policy like this is applied to a route that has a `/:customerId` parameter).
+This example would create a unique rate-limiting function based on the
+`customerId` parameter in routes (note it’s important that a policy like this is
+applied to a route that has a `/:customerId` parameter).
 
 ```ts
 //module - ./modules/rate-limiter.ts
@@ -38,7 +44,7 @@ export function rateLimitKey(
 ```
 
 ```json
-// config - ./config/routes.json
+// config - ./config/policies.json
 "export": "RateLimitInboundPolicy",
 "module": "$import(@zuplo/runtime)",
 "options": {

--- a/policies/validate-json-schema-inbound/doc.md
+++ b/policies/validate-json-schema-inbound/doc.md
@@ -41,8 +41,7 @@ purposes of this example let's imagine it is called `car.json`.
 
 ## Configuration
 
-Here is an example configuration (this would go in the `policies` section of the
-routes.json file).
+Here is an example configuration (this would go in `policies.json`).
 
 ```json
 {
@@ -104,7 +103,8 @@ You can test this in the API Test Console with the following (correct) body
 
 ### Missing fields
 
-If the request body is missing a required field, an error similar to the following will be returned.
+If the request body is missing a required field, an error similar to the
+following will be returned.
 
 ```json
 {
@@ -117,7 +117,8 @@ If the request body is missing a required field, an error similar to the followi
 
 ### Invalid Field Type
 
-If the request body contains a field that is not of the correct type, an error similar to the following will be returned.
+If the request body contains a field that is not of the correct type, an error
+similar to the following will be returned.
 
 ```json
 {


### PR DESCRIPTION
Remove references to `routes.json` in our docs, replacing with `routes.oas.json` or `policies.json` where necessary. I also replaced the code samples of `routes.json` I found. Images and gifs are harder to track down but less important, so I didn't try hard to remove those.