### PR TITLE
Document internal route handlers

### DIFF
--- a/docs/handlers/system-handlers.md
+++ b/docs/handlers/system-handlers.md
@@ -9,7 +9,6 @@ within your Analytics page. Below is a list of routes we have reserved:
 
 | Name                    | Method  | Path                              | Description                                                                                |
 | ----------------------- | ------- | --------------------------------- | ------------------------------------------------------------------------------------------ |
-| build-data              | GET     | `/__zuplo/build`                  | Provides information about the latest build of the gateway.                                |
 | cors-preflight          | OPTIONS | `/(.*)`                           | Handles CORS preflight requests.                                                           |
 | developer-portal        | GET     | User configured, default: `/docs` | Handles serving the developer portal. Can be [configured](../articles/dev-portal-json.md). |
 | developer-portal-legacy | GET     | `/__zuplo/dev-portal`             | Legacy path for the Developer Portal.                                                      |

--- a/docs/handlers/system-handlers.md
+++ b/docs/handlers/system-handlers.md
@@ -1,0 +1,17 @@
+---
+title: Internal Route Handlers
+sidebar_label: Internal Route Handlers
+---
+
+The Zuplo Runtime automatically registers certain routes on your gateway to
+provide enhanced functionality. You may see requests to these routes displayed
+within your Analytics page. Below is a list of routes we have reserved:
+
+| Name                    | Method  | Path                              | Description                                                                                |
+| ----------------------- | ------- | --------------------------------- | ------------------------------------------------------------------------------------------ |
+| build-data              | GET     | `/__zuplo/build`                  | Provides information about the latest build of the gateway.                                |
+| cors-preflight          | OPTIONS | `/(.*)`                           | Handles CORS preflight requests.                                                           |
+| developer-portal        | GET     | User configured, default: `/docs` | Handles serving the developer portal. Can be [configured](../articles/dev-portal-json.md). |
+| developer-portal-legacy | GET     | `/__zuplo/dev-portal`             | Legacy path for the Developer Portal.                                                      |
+| ping                    | GET     | `/__zuplo/ping`                   | Used to check liveness of deployments.                                                     |
+| unmatched-path          | All     | `/(.*)`                           | Handles requests to endpoints that have not been configured.                               |

--- a/sidebars.js
+++ b/sidebars.js
@@ -228,6 +228,7 @@ const sidebars = {
             "handlers/aws-lambda",
             "handlers/redirect",
             "handlers/open-api-handler",
+            "handlers/system-handlers",
           ],
         },
         {


### PR DESCRIPTION
## Summary
Documenting the internal routes we have registered. I did not intentionally document the `empty-gateway-catchall` route as I suppose that's an implementation detail the user doesn't need to know and wouldn't see in logs. I am not sure if this is too much / too little information so I am open to feedback

## Preview
<img width="1025" alt="image" src="https://github.com/zuplo/docs/assets/11202679/b158aab1-9967-49a8-81ca-9df746fe552b">
