### PR TITLE
disableAutomaticallyAddingKeyHeaderToOpenApi

### DIFF
--- a/policies/api-key-inbound/schema.json
+++ b/policies/api-key-inbound/schema.json
@@ -46,7 +46,7 @@
               "description": "The time to cache authentication results for a particular key. Higher values will decrease latency. Cached results will be valid until the cache expires even in the event the key is deleted, etc.."
             },
             "disableAutomaticallyAddingKeyHeaderToOpenApi": {
-              "type": "string",
+              "type": "boolean",
               "description": "Zuplo will automatically document your API key header within your OpenAPI specification & Developer Portal. Set this to `true` to disable this behavior."
             }
           }

--- a/policies/api-key-inbound/schema.json
+++ b/policies/api-key-inbound/schema.json
@@ -44,6 +44,10 @@
             "cacheTtlSeconds": {
               "type": "string",
               "description": "The time to cache authentication results for a particular key. Higher values will decrease latency. Cached results will be valid until the cache expires even in the event the key is deleted, etc.."
+            },
+            "disableAutomaticallyAddingKeyHeaderToOpenApi": {
+              "type": "string",
+              "description": "Zuplo will automatically document your API key header within your OpenAPI specification & Developer Portal. Set this to `true` to disable this behavior."
             }
           }
         }


### PR DESCRIPTION
## Summary
Some users will not want the current behavior of auto-adding the key header to the open api operation. This option will let them turn it off. TODO: Make changes in dev portal / build to accommodate this setting