### PR TITLE
ZUP-2474: Group docusaurus dependencies together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,9 @@ updates:
       prettier:
         patterns:
           - "*prettier*"
+      docusaurus:
+        patterns:
+          - "*docusaurus*"
+        updates-types:
+          - "minor"
+          - "patch"

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,8 @@
       },
       "devDependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",
-        "@docusaurus/module-type-aliases": "^2.2.0",
-        "@tsconfig/docusaurus": "^1.0.6",
+        "@docusaurus/module-type-aliases": "^2.4.1",
+        "@tsconfig/docusaurus": "^2.0.1",
         "@types/glob": "^8.0.0",
         "@types/jsdom": "^21.1.0",
         "@types/prettier": "^2.7.0",
@@ -3561,9 +3561,9 @@
       }
     },
     "node_modules/@tsconfig/docusaurus": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@tsconfig/docusaurus/-/docusaurus-1.0.7.tgz",
-      "integrity": "sha512-ffTXxGIP/IRMCjuzHd6M4/HdIrw1bMfC7Bv8hMkTadnePkpe0lG0oDSdbRpSDZb2rQMAgpbWiR10BvxvNYwYrg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/docusaurus/-/docusaurus-2.0.1.tgz",
+      "integrity": "sha512-7JrI61bTZ37DWrHx1qhOW+kPxSG95+/q+EiDCMIahh8Aqbk03+nVu+Z6YGOj3O5e6lXHJuf/LHJ/lc6j8IEQyA==",
       "dev": true
     },
     "node_modules/@tsconfig/node10": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
       "devDependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",
         "@docusaurus/module-type-aliases": "^2.4.1",
-        "@tsconfig/docusaurus": "^2.0.1",
+        "@tsconfig/docusaurus": "~1.0.7",
         "@types/glob": "^8.0.0",
         "@types/jsdom": "^21.1.0",
         "@types/prettier": "^2.7.0",
@@ -3561,9 +3561,9 @@
       }
     },
     "node_modules/@tsconfig/docusaurus": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/docusaurus/-/docusaurus-2.0.1.tgz",
-      "integrity": "sha512-7JrI61bTZ37DWrHx1qhOW+kPxSG95+/q+EiDCMIahh8Aqbk03+nVu+Z6YGOj3O5e6lXHJuf/LHJ/lc6j8IEQyA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@tsconfig/docusaurus/-/docusaurus-1.0.7.tgz",
+      "integrity": "sha512-ffTXxGIP/IRMCjuzHd6M4/HdIrw1bMfC7Bv8hMkTadnePkpe0lG0oDSdbRpSDZb2rQMAgpbWiR10BvxvNYwYrg==",
       "dev": true
     },
     "node_modules/@tsconfig/node10": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "^10.1.0",
     "@docusaurus/module-type-aliases": "^2.4.1",
-    "@tsconfig/docusaurus": "^2.0.1",
+    "@tsconfig/docusaurus": "~1.0.7",
     "@types/glob": "^8.0.0",
     "@types/jsdom": "^21.1.0",
     "@types/prettier": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
   },
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "^10.1.0",
-    "@docusaurus/module-type-aliases": "^2.2.0",
-    "@tsconfig/docusaurus": "^1.0.6",
+    "@docusaurus/module-type-aliases": "^2.4.1",
+    "@tsconfig/docusaurus": "^2.0.1",
     "@types/glob": "^8.0.0",
     "@types/jsdom": "^21.1.0",
     "@types/prettier": "^2.7.0",


### PR DESCRIPTION
I am not 100% if dependabot will upgrade all of them together but let's try.
Basically, the docusaurus ecosystem is released in lock step.
If you don't upgrade all of them, you _could_ see

```
[1] [ERROR] Invalid docusaurus-theme-mermaid version 2.3.1.
[1] All official @docusaurus/* packages should have the exact same version as @docusaurus/core (2.4.1).
[1] Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?
```