### PR TITLE
fix: Add missing SvgWrapper to copy icon

### DIFF
--- a/src/components/markdown/ui-icons.tsx
+++ b/src/components/markdown/ui-icons.tsx
@@ -7,6 +7,7 @@ import {
   PresentationIcon,
   RssIcon,
   ZapIcon,
+  CopyIcon as CopyIconLucide,
 } from "lucide-react";
 import { FC, PropsWithChildren } from "react";
 
@@ -61,21 +62,9 @@ export const DeveloperPortalIcon: FC = () => (
 );
 
 export const CopyIcon: FC = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    className="h-6 w-6"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke="currentColor"
-    strokeWidth={2}
-    style={{ rotate: "90deg" }}
-  >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
-    />
-  </svg>
+  <SvgWrapper>
+    <CopyIconLucide />
+  </SvgWrapper>
 );
 
 export const ShowIcon: FC = () => (


### PR DESCRIPTION
To be able to show this icon correctly inline we need the `SvgWrapper` wrapped around the icon.
I have replaced the custom icon with the Lucide icon for the sake of simplicity.

partially fixes: [ZUP-2753](https://linear.app/zuplo/issue/ZUP-2753/fix-inline-icons)