### PR TITLE
feat: Polish sidebar

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -10,7 +10,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <div className="hidden lg:relative lg:block lg:flex-none">
           <div className="absolute inset-y-0 right-0 w-[50vw] bg-gray-50 dark:hidden" />
           <div className="absolute bottom-0 right-0 top-0 hidden w-px bg-gray-800 dark:block" />
-          <div className="sticky top-[var(--header-height)] h-[calc(100vh-var(--header-height))] w-64 overflow-y-auto overflow-x-hidden pt-12 pr-8 xl:w-72 xl:pr-16">
+          <div className="sticky top-[var(--header-height)] h-[calc(100vh-var(--header-height))] w-64 overflow-y-auto overflow-x-hidden py-12 pr-8 xl:w-72 xl:pr-16">
             <Navigation />
           </div>
         </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -10,7 +10,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <div className="hidden lg:relative lg:block lg:flex-none">
           <div className="absolute inset-y-0 right-0 w-[50vw] bg-gray-50 dark:hidden" />
           <div className="absolute bottom-0 right-0 top-0 hidden w-px bg-gray-800 dark:block" />
-          <div className="sticky top-[var(--header-height)] h-[calc(100vh-var(--header-height))] w-64 overflow-y-auto overflow-x-hidden py-12 pr-8 xl:w-72 xl:pr-16">
+          <div className="sticky top-[var(--header-height)] h-[calc(100vh-var(--header-height))] w-64 overflow-y-auto overflow-x-hidden pt-12 pr-8 xl:w-72 xl:pr-16">
             <Navigation />
           </div>
         </div>

--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -11,7 +11,7 @@ type Props = {
 export function Navigation({ className }: Props) {
   return (
     <nav className={clsx("text-base lg:text-sm", className)}>
-      <ul role="list" className="space-y-5">
+      <ul role="list">
         {navigation.map((section) => (
           <NavigationCategory key={section.label} navItem={section} isRoot />
         ))}

--- a/src/components/navigation/NavigationCategory.tsx
+++ b/src/components/navigation/NavigationCategory.tsx
@@ -3,7 +3,7 @@ import { hasActiveNavLinkItem } from "@/lib/utils/has-active-nav-link-item";
 import clsx from "clsx";
 import { ChevronRightIcon } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { NavigationLinkItem } from "./NavigationLinkItem";
 
 type Props = {
@@ -23,19 +23,6 @@ function isCategoryExpanded(navItem: NavItem, pathname: string): boolean {
   return navItem.isExpandedByDefault || hasActiveNavLinkItem(navItem, pathname);
 }
 
-const recursiveHasActiveItemInCategory = (
-  navItem: NavItem,
-  pathname: string,
-): boolean => {
-  if (navItem.href && navItem.href === pathname) return true;
-
-  return (
-    navItem.items?.some((item) =>
-      recursiveHasActiveItemInCategory(item, pathname),
-    ) ?? false
-  );
-};
-
 export function NavigationCategory({ navItem, isRoot }: Props) {
   const pathname = usePathname();
   const router = useRouter();
@@ -46,21 +33,12 @@ export function NavigationCategory({ navItem, isRoot }: Props) {
 
   const onClick = () => {
     if (isCollapsed) {
-      const hasActiveItemInCategory = recursiveHasActiveItemInCategory(
-        navItem,
-        pathname,
-      );
-
-      if (!hasActiveItemInCategory) router.push(categoryHref);
+      if (!hasActiveNavLinkItem(navItem, pathname)) router.push(categoryHref);
       setIsCollapsed(false);
     } else {
       setIsCollapsed(true);
     }
   };
-
-  useEffect(() => {
-    setIsCollapsed(!isCategoryExpanded(navItem, pathname));
-  }, [pathname, navItem]);
 
   return (
     <li className={clsx(!isRoot && "pl-4")}>
@@ -81,11 +59,11 @@ export function NavigationCategory({ navItem, isRoot }: Props) {
       <ul
         role="list"
         className={clsx([
-          "grid duration-200 mt-2 space-y-2 border-l border-gray-100 dark:border-gray-800 lg:mt-4 lg:space-y-4 lg:border-gray-200",
+          "grid duration-200 mt-2 mb-4 border-l border-gray-100 dark:border-gray-800 lg:mt-4 lg:border-gray-200",
           isCollapsed ? "grid-rows-[0fr]" : "grid-rows-[1fr]",
         ])}
       >
-        <div className="overflow-hidden">
+        <div className="overflow-hidden flex flex-col gap-4">
           {navItem.items?.map((innerItem) =>
             innerItem.items?.length ? (
               <NavigationCategory navItem={innerItem} key={innerItem.label} />

--- a/src/components/navigation/NavigationCategory.tsx
+++ b/src/components/navigation/NavigationCategory.tsx
@@ -59,11 +59,13 @@ export function NavigationCategory({ navItem, isRoot }: Props) {
       <ul
         role="list"
         className={clsx([
-          "grid duration-200 mt-2 mb-4 border-l border-gray-100 dark:border-gray-800 lg:mt-4 lg:border-gray-200",
-          isCollapsed ? "grid-rows-[0fr]" : "grid-rows-[1fr]",
+          "grid duration-200 border-l border-gray-100 dark:border-gray-800 lg:border-gray-200",
+          isCollapsed ? "grid-rows-[0fr]" : "grid-rows-[1fr] ",
+          !isCollapsed && "my-3",
+          isRoot && "my-3",
         ])}
       >
-        <div className="overflow-hidden flex flex-col gap-4">
+        <div className="overflow-hidden flex flex-col gap-3">
           {navItem.items?.map((innerItem) =>
             innerItem.items?.length ? (
               <NavigationCategory navItem={innerItem} key={innerItem.label} />

--- a/src/components/navigation/NavigationCategory.tsx
+++ b/src/components/navigation/NavigationCategory.tsx
@@ -60,9 +60,8 @@ export function NavigationCategory({ navItem, isRoot }: Props) {
         role="list"
         className={clsx([
           "grid duration-200 border-l border-gray-100 dark:border-gray-800 lg:border-gray-200",
-          isCollapsed ? "grid-rows-[0fr]" : "grid-rows-[1fr] ",
-          !isCollapsed && "my-3",
-          isRoot && "my-3",
+          isCollapsed ? "grid-rows-[0fr]" : "grid-rows-[1fr]",
+          (!isCollapsed || isRoot) && "my-3",
         ])}
       >
         <div className="overflow-hidden flex flex-col gap-3">

--- a/src/components/navigation/NavigationCategory.tsx
+++ b/src/components/navigation/NavigationCategory.tsx
@@ -23,6 +23,19 @@ function isCategoryExpanded(navItem: NavItem, pathname: string): boolean {
   return navItem.isExpandedByDefault || hasActiveNavLinkItem(navItem, pathname);
 }
 
+const recursiveHasActiveItemInCategory = (
+  navItem: NavItem,
+  pathname: string,
+): boolean => {
+  if (navItem.href && navItem.href === pathname) return true;
+
+  return (
+    navItem.items?.some((item) =>
+      recursiveHasActiveItemInCategory(item, pathname),
+    ) ?? false
+  );
+};
+
 export function NavigationCategory({ navItem, isRoot }: Props) {
   const pathname = usePathname();
   const router = useRouter();
@@ -33,7 +46,13 @@ export function NavigationCategory({ navItem, isRoot }: Props) {
 
   const onClick = () => {
     if (isCollapsed) {
-      router.push(categoryHref);
+      const hasActiveItemInCategory = recursiveHasActiveItemInCategory(
+        navItem,
+        pathname,
+      );
+
+      if (!hasActiveItemInCategory) router.push(categoryHref);
+      setIsCollapsed(false);
     } else {
       setIsCollapsed(true);
     }
@@ -41,7 +60,7 @@ export function NavigationCategory({ navItem, isRoot }: Props) {
 
   useEffect(() => {
     setIsCollapsed(!isCategoryExpanded(navItem, pathname));
-  }, [pathname, setIsCollapsed, navItem]);
+  }, [pathname, navItem]);
 
   return (
     <li className={clsx(!isRoot && "pl-4")}>

--- a/src/components/navigation/NavigationCategory.tsx
+++ b/src/components/navigation/NavigationCategory.tsx
@@ -47,7 +47,7 @@ export function NavigationCategory({ navItem, isRoot }: Props) {
     <li className={clsx(!isRoot && "pl-4")}>
       <a
         className={clsx([
-          "flex w-full cursor-pointer",
+          "flex w-full cursor-pointer items-center",
           isRoot
             ? "font-display font-semibold text-gray-900 dark:text-white"
             : "text-gray-500 dark:text-gray-400 dark:hover:text-gray-300",

--- a/src/components/navigation/NavigationCategory.tsx
+++ b/src/components/navigation/NavigationCategory.tsx
@@ -1,7 +1,7 @@
 import { NavItem } from "@/lib/interfaces";
 import { hasActiveNavLinkItem } from "@/lib/utils/has-active-nav-link-item";
 import clsx from "clsx";
-import { ChevronRightIcon, ChevronDownIcon } from "lucide-react";
+import { ChevronRightIcon } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { NavigationLinkItem } from "./NavigationLinkItem";
@@ -55,26 +55,26 @@ export function NavigationCategory({ navItem, isRoot }: Props) {
         onClick={onClick}
       >
         <span className="flex-grow">{navItem.label}</span>
-        {isCollapsed ? (
-          <ChevronRightIcon className="h-4 w-4" />
-        ) : (
-          <ChevronDownIcon className="h-4 w-4" />
-        )}
+        <ChevronRightIcon
+          className={clsx("h-4 w-4 duration-200", !isCollapsed && "rotate-90")}
+        />
       </a>
       <ul
         role="list"
         className={clsx([
-          "mt-2 space-y-2 border-l border-gray-100 dark:border-gray-800 lg:mt-4 lg:space-y-4 lg:border-gray-200",
-          isCollapsed && "hidden",
+          "grid duration-200 mt-2 space-y-2 border-l border-gray-100 dark:border-gray-800 lg:mt-4 lg:space-y-4 lg:border-gray-200",
+          isCollapsed ? "grid-rows-[0fr]" : "grid-rows-[1fr]",
         ])}
       >
-        {navItem.items?.map((innerItem) =>
-          innerItem.items?.length ? (
-            <NavigationCategory navItem={innerItem} key={innerItem.label} />
-          ) : (
-            <NavigationLinkItem link={innerItem} key={innerItem.label} />
-          ),
-        )}
+        <div className="overflow-hidden">
+          {navItem.items?.map((innerItem) =>
+            innerItem.items?.length ? (
+              <NavigationCategory navItem={innerItem} key={innerItem.label} />
+            ) : (
+              <NavigationLinkItem link={innerItem} key={innerItem.label} />
+            ),
+          )}
+        </div>
       </ul>
     </li>
   );


### PR DESCRIPTION
Fixes [ZUP-2752](https://linear.app/zuplo/issue/ZUP-2752/polish-the-docs-sidebar)

- Add nice animation for expanding/collapsing a category
- Allow to expand/collapse multiple times
- Center category arrow/chevron
- Removed auto collapse when switching category
  - Personally, I don't think categories should automatically collapse in a larger documentation. Sometimes I need to jump back and forth between multiple pages, and automatically collapsing categories makes it hard to keep track of where things are, and introduces mental overhead.

<table>
<tr>
<th>Before
<th>After
<tr>
<td><video src="https://github.com/zuplo/docs/assets/571589/46b5d1c2-2c71-41be-8307-4215412f51a8">
<td><video src="https://github.com/zuplo/docs/assets/571589/d848d688-04a4-4f2b-a355-f5ca2cc1bc64">

