### PR TITLE
fix: Hide scroll content above the header

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -28,7 +28,12 @@ export default function Header() {
   }, []);
 
   return (
-    <header className="max-w-wide sticky top-0 pt-4 z-50 w-full [@supports(backdrop-filter:blur(0))]:backdrop-blur-[2px]">
+    <header
+      className={clsx(
+        "max-w-wide sticky top-0 pt-4 z-50 w-full",
+        "before:content-[''] before:h-4 before:inset-0 before:absolute before:bg-white before:dark:bg-black",
+      )}
+    >
       <div
         className={clsx(
           "max-w-wide flex h-24 w-full flex-none flex-wrap items-center justify-between rounded-xl bg-black/95 px-6 py-5 shadow-md shadow-gray-900/25 transition duration-500 lg:px-8",


### PR DESCRIPTION
Based on feedback in Slack: https://zuplo.slack.com/archives/C03813YKQ8G/p1708116978630959

Instead of blurring, there's now an element that sits on top of the header and blocks the view of the scrollable content.