### PR TITLE
fix: Show list items in dark mode

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -105,6 +105,11 @@ export default {
             ul: {
               color: "white",
             },
+            li: {
+              "&::marker": {
+                color: "white",
+              },
+            },
           },
         },
       }),


### PR DESCRIPTION
Add missing style declaration

<img src="https://github.com/zuplo/docs/assets/571589/3c717593-6d81-4bcd-ba21-6bab14a5b738" width=500>
