### PR TITLE
feat: Scroll active link item into view

### DIFF
--- a/src/components/navigation/NavigationLinkItem.tsx
+++ b/src/components/navigation/NavigationLinkItem.tsx
@@ -2,6 +2,7 @@ import { NavItem } from "@/lib/interfaces";
 import { usePathname } from "next/navigation";
 import clsx from "clsx";
 import Link from "next/link";
+import { useEffect, useRef } from "react";
 
 type Props = {
   link: NavItem;
@@ -10,9 +11,19 @@ type Props = {
 export function NavigationLinkItem({ link }: Props) {
   const pathname = usePathname();
   const isActive = link.href === pathname;
+  const ranOnce = useRef(false);
+  const liRef = useRef<HTMLLIElement>(null);
+
+  useEffect(() => {
+    if (ranOnce.current || !liRef.current) return;
+
+    liRef.current.scrollIntoView({ block: "nearest" });
+    ranOnce.current = true;
+  }, [isActive]);
 
   return (
     <li
+      ref={liRef}
       className={clsx(
         "pl-4 border-l hover:border-pink",
         isActive ? "border-pink" : "border-transparent",


### PR DESCRIPTION
When redirecting to a doc page, the active link is buried somewhere in the scrollable area, requiring the user to scroll down manually.
This PR addresses that and scrolls down on the initial render.