### PR TITLE
fix: Close mobile menu only on leaf items

### DIFF
--- a/src/components/navigation/MobileNavigation.tsx
+++ b/src/components/navigation/MobileNavigation.tsx
@@ -1,31 +1,30 @@
 "use client";
 
-import { Suspense, useCallback, useEffect, useState } from "react";
+import { createContext, useCallback, useContext, useState } from "react";
 import Link from "next/link";
-import { usePathname, useSearchParams } from "next/navigation";
 import { Dialog } from "@headlessui/react";
 
 import { Logomark } from "@/components/Logo";
 import { Navigation } from "@/components/navigation/Navigation";
 import { MenuIcon, XIcon } from "lucide-react";
 
-function CloseOnNavigation({ close }: { close: () => void }) {
-  let pathname = usePathname();
-  let searchParams = useSearchParams();
+const MobileNavigationContext = createContext<{
+  isOpen: boolean;
+  close: () => void;
+}>({
+  isOpen: false,
+  // default is close function is a noop (for non-mobile)
+  close: () => {},
+});
 
-  useEffect(() => {
-    close();
-  }, [pathname, searchParams, close]);
-
-  return null;
-}
+export const useMobileNavigation = () => useContext(MobileNavigationContext);
 
 export function MobileNavigation() {
   let [isOpen, setIsOpen] = useState(false);
   let close = useCallback(() => setIsOpen(false), [setIsOpen]);
 
   return (
-    <>
+    <MobileNavigationContext.Provider value={{ isOpen, close }}>
       <button
         type="button"
         onClick={() => setIsOpen(true)}
@@ -34,9 +33,6 @@ export function MobileNavigation() {
       >
         <MenuIcon className="h-6 w-6 stroke-gray-500" />
       </button>
-      <Suspense fallback={null}>
-        <CloseOnNavigation close={close} />
-      </Suspense>
       <Dialog
         open={isOpen}
         onClose={() => close()}
@@ -59,6 +55,6 @@ export function MobileNavigation() {
           <Navigation className="mt-5 px-1" />
         </Dialog.Panel>
       </Dialog>
-    </>
+    </MobileNavigationContext.Provider>
   );
 }

--- a/src/components/navigation/NavigationLinkItem.tsx
+++ b/src/components/navigation/NavigationLinkItem.tsx
@@ -3,6 +3,7 @@ import { usePathname } from "next/navigation";
 import clsx from "clsx";
 import Link from "next/link";
 import { useEffect, useRef } from "react";
+import { useMobileNavigation } from "./MobileNavigation";
 
 type Props = {
   link: NavItem;
@@ -13,6 +14,7 @@ export function NavigationLinkItem({ link }: Props) {
   const isActive = link.href === pathname;
   const ranOnce = useRef(false);
   const liRef = useRef<HTMLLIElement>(null);
+  const { close } = useMobileNavigation();
 
   useEffect(() => {
     if (ranOnce.current || !liRef.current) return;
@@ -31,6 +33,7 @@ export function NavigationLinkItem({ link }: Props) {
     >
       <Link
         href={link.href!}
+        onClick={close}
         className={clsx(
           "block w-full",
           isActive


### PR DESCRIPTION
Fixes [ZUP-2806](https://linear.app/zuplo/issue/ZUP-2806/mobile-nav-on-docs-doesnt-work-well)

Close the menu explicitly instead of listening to path/query param changes