### PR TITLE
Adjust AI chat styles

### DIFF
--- a/public/styles/inkeep.css
+++ b/public/styles/inkeep.css
@@ -1,0 +1,37 @@
+#inkeep-widget-root {
+  --ai-chat-radius: 0.25rem;
+  --ai-chat-light-background: #f9fafb;
+}
+
+.ikp-ai-chat__header-toolbar {
+  display: none;
+}
+
+.ikp-ai-chat__scrollable-page-content {
+  border-top-left-radius: var(--ai-chat-radius);
+  border-top-right-radius: var(--ai-chat-radius);
+}
+
+.ikp-ai-chat-footer__content-wrapper {
+  border-bottom-left-radius: var(--ai-chat-radius);
+  border-bottom-right-radius: var(--ai-chat-radius);
+}
+
+[data-theme="light"] .ikp-ai-chat__scrollable-page-content {
+  background: var(--ai-chat-light-background);
+}
+
+[data-theme="light"] .ikp-ai-chat-footer__content-wrapper {
+  background: var(--ai-chat-light-background);
+}
+
+[data-theme="light"] .ikp-ai-chat__message-box {
+  box-shadow: none;
+  border: 1px solid #e0e0e0;
+  background: #fff;
+}
+
+/* Remove weird blur effect on footer */
+.ikp-ai-chat-footer__content-wrapper::before {
+  display: none;
+}

--- a/src/app/ask/embedded.tsx
+++ b/src/app/ask/embedded.tsx
@@ -1,6 +1,7 @@
 "use client";
-import { InkeepEmbeddedChatProps } from "@inkeep/widgets";
 import dynamic from "next/dynamic";
+import { useTheme } from "next-themes";
+
 import { aiChatSettings, baseSettings } from "../../lib/search";
 
 const EmbeddedChat = dynamic(
@@ -12,12 +13,20 @@ const EmbeddedChat = dynamic(
 );
 
 function InkeepEmbeddedChat() {
-  const embeddedChatProps: InkeepEmbeddedChatProps = {
-    baseSettings,
-    aiChatSettings,
-  };
+  const { resolvedTheme } = useTheme();
 
-  return <EmbeddedChat {...embeddedChatProps} />;
+  return (
+    <EmbeddedChat
+      stylesheetUrls={["/docs/styles/inkeep.css"]}
+      baseSettings={{
+        ...baseSettings,
+        colorMode: {
+          forcedColorMode: resolvedTheme,
+        },
+      }}
+      aiChatSettings={aiChatSettings}
+    />
+  );
 }
 
 export default InkeepEmbeddedChat;

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -13,6 +13,12 @@ const baseSettings: InkeepWidgetBaseSettings = {
   organizationDisplayName: "Zuplo",
   theme: {
     components: {
+      AIChatPageWrapper: {
+        defaultProps: {
+          size: "shrink-vertically",
+          variant: "no-shadow",
+        },
+      },
       SearchBarTrigger: {
         defaultProps: {
           size: "expand",


### PR DESCRIPTION
I've updated the styles to fit better into the docs and also added dark/light theme support.

It's weird to adjust styles with [Inkeep's API](https://docs.inkeep.com/customization-guides/style-components) and requires some hacks/workarounds as it is rendered in its own shadow DOM, but I've got it working in the end.

__Screenshots:__

<img src="https://github.com/zuplo/docs/assets/571589/f5630abb-3815-43a0-9d7e-573b059c4a38" width=600>
<br>
<img src="https://github.com/zuplo/docs/assets/571589/8e45b3b8-1100-45ae-964e-67f08f5de160" width=600>
