### PR TITLE
Fix static CDN images

### DIFF
--- a/src/mdx/static-images.ts
+++ b/src/mdx/static-images.ts
@@ -20,8 +20,8 @@ const rehypeStaticImages: Plugin<[], Root, Root> =
           ) {
             if (!node.properties.src.startsWith("http")) {
               let url = node.properties.src;
-              const relativePath = url.startsWith("/public/")
-                ? `/docs${url.substring("/public".length)}`
+              const relativePath = url.startsWith("/")
+                ? `/docs/${url.replace(/^\//, "")}`
                 : url;
               if (process.env.USE_IMAGE_CDN) {
                 node.properties.src = `https://cdn.zuplo.com${relativePath}`;


### PR DESCRIPTION
The paths don't start with `/public` these are stripped before:

https://github.com/zuplo/docs/blob/6b8642e258b8d0cf78a82023bf36b4fbed1df8e1/scripts/fix-markdown.ts#L1-L7