### PR TITLE
Support relative URLs for images

### DIFF
--- a/src/mdx/static-images.ts
+++ b/src/mdx/static-images.ts
@@ -18,13 +18,14 @@ const rehypeStaticImages: Plugin<[], Root, Root> =
             node.tagName === "img" &&
             node.properties
           ) {
-            console.log(node.properties.src);
             if (!node.properties.src.startsWith("http")) {
               let url = node.properties.src;
               let relativePath = url;
+              // Ex. Direct /media references
               if (url.startsWith("/")) {
                 relativePath = `/docs${url}`;
               } else if (url.startsWith("../../public/")) {
+                // Ex. relative navigation to the public/media folder
                 relativePath = url.replace("../../public/", "/docs/");
               }
               if (process.env.USE_IMAGE_CDN) {

--- a/src/mdx/static-images.ts
+++ b/src/mdx/static-images.ts
@@ -18,11 +18,15 @@ const rehypeStaticImages: Plugin<[], Root, Root> =
             node.tagName === "img" &&
             node.properties
           ) {
+            console.log(node.properties.src);
             if (!node.properties.src.startsWith("http")) {
               let url = node.properties.src;
-              const relativePath = url.startsWith("/")
-                ? `/docs/${url.replace(/^\//, "")}`
-                : url;
+              let relativePath = url;
+              if (url.startsWith("/")) {
+                relativePath = `/docs${url}`;
+              } else if (url.startsWith("../../public/")) {
+                relativePath = url.replace("../../public/", "/docs/");
+              }
               if (process.env.USE_IMAGE_CDN) {
                 node.properties.src = new URL(
                   relativePath,


### PR DESCRIPTION
Images in our docs are broken. The CDN links are missing the `/docs` portion prior to the `/media`. I think this only affects pages that do `../../public...` for their images paths like the getting started guide.

I hope this aligns with the changes @ntotten wanted to make [here](https://github.com/zuplo/docs/commit/7471b3ebcb5a51948d24871444eb087804dfc708)