### PR TITLE
Add Aserto to Authorization sidebar

### DIFF
--- a/sidebar.ts
+++ b/sidebar.ts
@@ -416,6 +416,7 @@ export const policies: SidebarEntry = [
     type: "category",
     label: "Authorization",
     items: [
+      "policies/aserto-authz-inbound",
       "policies/okta-fga-authz-inbound",
       "policies/openfga-authz-inbound",
       "policies/axiomatics-authz-inbound",

--- a/sidebar.ts
+++ b/sidebar.ts
@@ -417,6 +417,7 @@ export const policies: SidebarEntry = [
     label: "Authorization",
     items: [
       "policies/aserto-authz-inbound",
+      "policies/authzen-inbound",
       "policies/okta-fga-authz-inbound",
       "policies/openfga-authz-inbound",
       "policies/axiomatics-authz-inbound",


### PR DESCRIPTION
Our Aserto and AuthZEN policies are missing the whole left sidebar due to not being featured in the Authorization section of `sidebar.ts`. This fixes that.