### PR TITLE
Avoid zuplopreview from being indexed

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -871,7 +871,18 @@
         {
           "key": "X-Frame-Options",
           "value": "DENY"
-        },
+        }
+      ]
+    },
+    {
+      "source": "/(.*)",
+      "has": [
+        {
+          "type": "host",
+          "value": "zuplo.com"
+        }
+      ],
+      "headers": [
         {
           "key": "X-Robots-Tag",
           "value": "all"


### PR DESCRIPTION
Google is accidentally picking up some `zuplopreview.net` urls 
<img width="907" alt="image" src="https://github.com/user-attachments/assets/57074fa9-9ead-4860-9403-5aac1e16896f" />

We need to set `Z-Robots-Tag` 5o `all` because we proxy the request to our docs through zuplo.com (see https://vercel.com/docs/headers/response-headers#x-robots-tag). What I didn't realize is that preview builds might also get indexed. Instead, I only want the proxied requests to get indexed which I think I can achieve with the `has` rule (https://vercel.com/docs/project-configuration#header-has-or-missing-object-definition)