### PR TITLE
Fix broken internal zudoku links

### DIFF
--- a/docs/dev-portal/introduction.md
+++ b/docs/dev-portal/introduction.md
@@ -1,5 +1,6 @@
 ---
 title: Introduction
+description: Introduction to Zuplo's beautiful, auto-generated developer portal.
 ---
 
 :::warning

--- a/docs/dev-portal/migration.md
+++ b/docs/dev-portal/migration.md
@@ -391,7 +391,7 @@ Your new developer portal may also change other paths. To create redirects for
 specific docs or other path in your new Dev Portal, we recommend using the
 `redirects` configuration in the `zudoku.config.tsx` file. This allows you to
 specify multiple redirects easily. For more information, see the
-[Redirects section in the configuration docs](/docs/dev-portal/introduction/zudoku/configuration/overview#redirects)
+[Redirects section in the configuration docs](/docs/dev-portal/zudoku/configuration/overview#redirects)
 
 ## Troubleshooting
 

--- a/docs/dev-portal/migration.md
+++ b/docs/dev-portal/migration.md
@@ -1,6 +1,8 @@
 ---
 title: Dev Portal Migration Guide
 sidebar_label: Migration Guide
+description:
+  Instruction for migrating from the legacy developer portal to Zudoku.
 ---
 
 :::warning

--- a/docs/dev-portal/node-modules.md
+++ b/docs/dev-portal/node-modules.md
@@ -1,5 +1,5 @@
 ---
-title: Node Modules
+title: Node Modules & Customization
 ---
 
 :::warning

--- a/docs/dev-portal/node-modules.md
+++ b/docs/dev-portal/node-modules.md
@@ -1,5 +1,7 @@
 ---
 title: Node Modules & Customization
+description:
+  Guide to installing custom node modules in Zuplo's developer portal.
 ---
 
 :::warning

--- a/docs/dev-portal/updating.md
+++ b/docs/dev-portal/updating.md
@@ -1,5 +1,8 @@
 ---
 title: Updating Versions
+description:
+  How to update Zuplo's developer portal to keep it up to date with the latest
+  changes.
 ---
 
 :::warning

--- a/docs/legacy/dev-portal/dev-portal-adding-pages.md
+++ b/docs/legacy/dev-portal/dev-portal-adding-pages.md
@@ -1,5 +1,9 @@
 ---
 title: Custom Pages
+description:
+  Learn how to add and configure custom pages in your LEGACY Zuplo developer
+  portal, including editing markdown, previewing changes, and managing sidebar
+  navigation for a tailored API documentation experience.
 ---
 
 :::danger

--- a/docs/legacy/dev-portal/dev-portal-auth.md
+++ b/docs/legacy/dev-portal/dev-portal-auth.md
@@ -1,6 +1,11 @@
 ---
 title: Dev Portal Authentication
 sidebar_label: Overview
+description:
+  Learn how to configure authentication for the LEGACY Zuplo Developer Portal
+  using popular OpenID Connect providers like Auth0, Okta, AWS Cognito, Clerk,
+  and Supabase. This guide covers setup instructions and important
+  considerations for production environments.
 ---
 
 :::danger

--- a/docs/legacy/dev-portal/dev-portal-auth0-auth.md
+++ b/docs/legacy/dev-portal/dev-portal-auth0-auth.md
@@ -1,6 +1,10 @@
 ---
 title: Dev Portal Auth0 Setup
 sidebar_label: Auth0 Setup
+description:
+  Learn how to set up Auth0 authentication for the LEGACY Zuplo Developer
+  Portal, including application configuration, API creation, and portal
+  integration steps for secure API access.
 ---
 
 :::danger

--- a/docs/legacy/dev-portal/dev-portal-clerk-auth.md
+++ b/docs/legacy/dev-portal/dev-portal-clerk-auth.md
@@ -1,6 +1,10 @@
 ---
 title: Dev Portal Clerk Setup
 sidebar_label: Clerk Setup
+description:
+  Learn how to set up Clerk authentication for the LEGACY Zuplo Developer
+  Portal, including creating an OAuth application, configuring environment
+  variables, and updating your portal settings.
 ---
 
 :::danger

--- a/docs/legacy/dev-portal/dev-portal-configuration.md
+++ b/docs/legacy/dev-portal/dev-portal-configuration.md
@@ -1,5 +1,10 @@
 ---
 title: OpenAPI Specifications
+description:
+  Learn how Zuplo leverages OpenAPI specifications to power the LEGACY developer
+  portal documentation. Discover supported OpenAPI versions, handling multiple
+  specs, embedding JSON Schemas, and configuring examples for your API
+  documentation.
 ---
 
 :::danger

--- a/docs/legacy/dev-portal/dev-portal-configuring-sidebar.md
+++ b/docs/legacy/dev-portal/dev-portal-configuring-sidebar.md
@@ -1,5 +1,10 @@
 ---
 title: Sidebar Configuration
+description:
+  Learn how to configure the sidebar of your LEGACY Zuplo Developer Portal using
+  the sidebar.json file. This guide covers sidebar item types, labels, OpenAPI
+  spec customization, and practical examples for effective API documentation
+  navigation.
 ---
 
 :::danger

--- a/docs/legacy/dev-portal/dev-portal-create-consumer-on-auth.md
+++ b/docs/legacy/dev-portal/dev-portal-create-consumer-on-auth.md
@@ -1,5 +1,9 @@
 ---
 title: Create an API Key Consumer on Login
+description:
+  Learn how to automatically create an API Key Consumer for users upon login to
+  your LEGACY Developer Portal using Auth0 actions. This guide provides
+  step-by-step instructions for integrating with the legacy Dev Portal.
 ---
 
 :::danger

--- a/docs/legacy/dev-portal/dev-portal-inject-html.md
+++ b/docs/legacy/dev-portal/dev-portal-inject-html.md
@@ -1,6 +1,10 @@
 ---
 title: Developer Portal Inject Custom Html
 sidebar_label: Inject Custom Html
+description:
+  Learn how to inject custom HTML and handle authentication events in the LEGACY
+  Zuplo Developer Portal, including practical examples for adding scripts and
+  listening to user identification.
 ---
 
 :::danger

--- a/docs/legacy/dev-portal/dev-portal-json.md
+++ b/docs/legacy/dev-portal/dev-portal-json.md
@@ -1,5 +1,9 @@
 ---
 title: Config (dev-portal.json)
+description:
+  Learn how to configure the LEGACY Zuplo Developer Portal using the
+  dev-portal.json file, including enabling features, customizing authentication,
+  and mapping environment variables for secure and flexible API management.
 ---
 
 :::danger

--- a/docs/legacy/dev-portal/dev-portal-keycloak-auth.md
+++ b/docs/legacy/dev-portal/dev-portal-keycloak-auth.md
@@ -1,6 +1,9 @@
 ---
 title: Dev Portal Keycloak Setup
 sidebar_label: Keycloak Setup
+description:
+  Learn how to configure Keycloak as the authentication provider for your LEGACY
+  Zuplo hosted developer portal with this step-by-step guide.
 ---
 
 :::danger

--- a/docs/legacy/dev-portal/dev-portal-setup.md
+++ b/docs/legacy/dev-portal/dev-portal-setup.md
@@ -1,6 +1,10 @@
 ---
 title: Developer Portal Setup
 sidebar_label: Setup
+description:
+  Learn how to set up and customize your LEGACY Zuplo Developer Portal,
+  including an overview of key configuration files and tips for managing your
+  API documentation effectively.
 ---
 
 :::danger

--- a/docs/legacy/dev-portal/dev-portal-supabase-auth.md
+++ b/docs/legacy/dev-portal/dev-portal-supabase-auth.md
@@ -1,6 +1,11 @@
 ---
 title: Dev Portal Supabase Setup
 sidebar_label: Supabase Setup
+description:
+  Learn how to integrate Supabase authentication with your LEGACY Zuplo
+  Developer Portal, enabling your users to sign up, sign in, and manage API
+  access securely using Supabase Auth. This step-by-step guide covers setup,
+  configuration, and best practices for a seamless developer experience.
 ---
 
 :::danger

--- a/docs/legacy/dev-portal/dev-portal-theme.md
+++ b/docs/legacy/dev-portal/dev-portal-theme.md
@@ -1,6 +1,11 @@
 ---
 title: Developer Portal Theme
 sidebar_label: Theming
+description:
+  Learn how to customize the appearance of your LEGACY Zuplo Developer Portal
+  using supported CSS variables and theming options. This guide covers theme
+  classes, logo configuration, and best practices for safely applying custom
+  styles.
 ---
 
 :::danger

--- a/docs/legacy/dev-portal/overview.md
+++ b/docs/legacy/dev-portal/overview.md
@@ -1,6 +1,7 @@
 ---
 title: Developer Portal (Legacy)
 sidebar_label: Overview
+description: Overview of the legacy developer portal.
 ---
 
 :::danger

--- a/docs/legacy/dev-portal/overview.md
+++ b/docs/legacy/dev-portal/overview.md
@@ -49,9 +49,9 @@ etc. you should ensure you have completed the following steps.
 1. **[Add custom documentation](./dev-portal-adding-pages.md)** - Often you will
    want to add additional instructions to your API docs.
 
-1. **[Configure a Custom Domain](./custom-domains.md)** - If you are on one of
-   our paid plans, you will want to host your gateway on something like
-   `api.example.com` so that your customers can access your docs at
+1. **[Configure a Custom Domain](/docs/articles/custom-domains)** - If you are
+   on one of our paid plans, you will want to host your gateway on something
+   like `api.example.com` so that your customers can access your docs at
    `https://api.example.com/docs`.
 
 1. **[Create Consumers on Login](./dev-portal-create-consumer-on-auth.md)** -

--- a/scripts/update-zudoku-docs.mts
+++ b/scripts/update-zudoku-docs.mts
@@ -26,7 +26,10 @@ async function updateDocs(dir: string) {
       if (stat.isFile()) {
         let content = await fs.readFile(filePath, "utf8");
 
-        content = content.replace(new RegExp("Zudoku ", "g"), "Dev Portal ");
+        content = content
+          .replace(new RegExp("Zudoku ", "g"), "Dev Portal ")
+          // Rewrite internal links to start with /dev-portal/zudoku/
+          .replace(/(?<=\]\()\//g, "/dev-portal/zudoku/");
 
         // Insert text after frontmatter
         const frontmatterEndIndex = content.indexOf("---", 3) + 3;


### PR DESCRIPTION
Internal markdown links like
```md
[Markdown Overview](/markdown/overview)
```
in the imported Zudoku docs are broken.

Those that aren't relative to the current directory are currently broken in the dev portal docs, because the Zuplo docs don't have the same path hierarchy.

This PR rewrites the paths so they work, similar to what's done [in the sidebar](https://github.com/zuplo/docs/blob/8b0c2647f6a8951d019af2589b8155969553a331/scripts/update-zudoku-sidebar.mts#L32-L33)

I also tossed in some general docs cleanup