### PR TITLE
fix: Fixup MCP custom tools links

### DIFF
--- a/docs/ai/mcp.md
+++ b/docs/ai/mcp.md
@@ -204,6 +204,6 @@ const checkCustomerOrder = mcpSdk.defineTool({
 ## Learn More
 
 - [MCP Server Handler Technical Documentation](/docs/handlers/mcp-server)
-- [MCP Custom Tools Documentation](/docs/handlers/mcp-custom-tools)
+- [MCP Custom Tools Documentation](/docs/programmable-api/mcp-custom-tools)
 - [Model Context Protocol Specification](https://spec.modelcontextprotocol.io/)
 - [OpenAPI Specification](https://swagger.io/specification/)

--- a/docs/programmable-api/index.md
+++ b/docs/programmable-api/index.md
@@ -133,7 +133,7 @@ request handlers.
 ### McpCustomToolsPlugin
 
 - **Status**: Documented
-  ([MCP Custom Tools](/docs/handlers/mcp-custom-tools.md))
+  ([MCP Custom Tools](/docs/programmable-api/mcp-custom-tools.md))
 - **Description**: Create programmable MCP tools with custom business logic
 - **Key Features**: Type-safe tool definitions, multi-step workflows, runtime
   integration


### PR DESCRIPTION
Fixes a few links to the `programmable-api/mcp-custom-tools` docs