### PR TITLE
fix: Correct MCP links and format for "tip" in URL forward handler

### DIFF
--- a/docs/handlers/url-forward.md
+++ b/docs/handlers/url-forward.md
@@ -8,9 +8,13 @@ code. It appends the incoming path section of the URL onto the specified
 `baseUrl` property, making it ideal for creating API gateways and backend
 proxying.
 
-:::tip Type-Safe Configuration Use TypeScript for enhanced development
+:::tip
+
+Type-Safe Configuration Use TypeScript for enhanced development
 experience with full type checking and IntelliSense support when configuring
-handlers. :::
+handlers.
+
+:::
 
 ## How It Works
 

--- a/docs/programmable-api/mcp-custom-tools.md
+++ b/docs/programmable-api/mcp-custom-tools.md
@@ -10,7 +10,7 @@ implement custom business logic, and provide rich responses to AI systems.
 
 :::tip
 
-This is more powerful than the [MCP Server Handler](./handlers/mcp-server.md)
+This is more powerful than the [MCP Server Handler](../handlers/mcp-server.md)
 which automatically transforms your OpenAPI routes into MCP tools. Custom MCP
 Tools give you full programmatic control over tool behavior.
 
@@ -408,7 +408,7 @@ outputSchema: z.object({
 
 ## Learn More
 
-- [MCP Server Handler](./handler/mcp-server.md) - For simple route-to-tool
+- [MCP Server Handler](../handlers/mcp-server.md) - For simple route-to-tool
   mapping
 - [Model Context Protocol Overview](/docs/ai/mcp) - Understanding MCP concepts
 - [MCP Specification](https://modelcontextprotocol.io/specification/) - Official


### PR DESCRIPTION
Fixes a few MCP related links and a formatting error for a `:::tip` I found