### PR TITLE
Add query param to header policy to sidebar

### DIFF
--- a/sidebar.ts
+++ b/sidebar.ts
@@ -541,6 +541,7 @@ export const policies: Navigation = [
       "policies/set-headers-inbound",
       "policies/set-body-inbound",
       "policies/set-query-params-inbound",
+      "policies/query-param-to-header-inbound"
     ],
   },
   {


### PR DESCRIPTION
Query Param to Header Policy missing from sidebar, so doesn't have the full nav. This fixes that.