### PR TITLE
Fix orphaned links

### DIFF
--- a/sidebar.ts
+++ b/sidebar.ts
@@ -651,6 +651,36 @@ export const legacy: Navigation = [
       },
     ],
   },
+  {
+    type: "doc",
+    display: "hide",
+    file: "articles/going-live",
+  },
+  {
+    type: "doc",
+    display: "hide",
+    file: "articles/testing-api-key-authentication",
+  },
+  {
+    type: "doc",
+    display: "hide",
+    file: "articles/securing-backend-shared-secret",
+  },
+  {
+    type: "doc",
+    display: "hide",
+    file: "articles/oauth-authentication",
+  },
+  {
+    type: "doc",
+    display: "hide",
+    file: "articles/developer-api",
+  },
+  {
+    type: "doc",
+    display: "hide",
+    file: "articles/performance-testing",
+  },
 ];
 
 export const devPortal: Navigation = [


### PR DESCRIPTION
## Summary

[See slack thread](https://zuplo.slack.com/archives/C03813YKQ8G/p1752608090731659). Essentially, you can't have "orphaned" pages in Zudoku anymore. Orphans are pages not referenced in the `sidebar.ts`. The suggested fix is to reference all the pages but hide them from nav