### PR TITLE
feat: Okta MCP auth docs

### DIFF
--- a/docs/articles/configuring-okta-for-mcp-auth.md
+++ b/docs/articles/configuring-okta-for-mcp-auth.md
@@ -181,7 +181,7 @@ will need to do the following:
      your Okta authorization server.
 
    This plugin populates the `.well-known` routes for the MCP server auth
-   metadata discover. This enables MCP clients to automatically discover the
+   metadata discovery. This enables MCP clients to automatically discover the
    authorization issuer endpoint. See the
    [OAuth Protected Resource Plugin docs](../programmable-api/oauth-protected-resource-plugin)
    for more details on this runtime plugin.

--- a/docs/articles/configuring-okta-for-mcp-auth.md
+++ b/docs/articles/configuring-okta-for-mcp-auth.md
@@ -1,0 +1,199 @@
+---
+title: Setting up Okta as an Authentication Server for MCP OAuth Authentication
+---
+
+In this guide, you'll learn how to configure Okta as an authorization server for
+use with the MCP Server handler. See the
+[MCP Server Handler docs](../handlers/mcp-server.md#oauth-authentication) for
+instructions on how to configure your Zuplo gateway to support OAuth
+authentication for your MCP Server.
+
+This guide will assume that you already have a working Okta account and
+organization.
+
+## Create an Auth Server
+
+First, you will need to create an Okta authorization server. This server will be
+used to authorize requests to your MCP Server per
+[the Model Context Protocol authorization specification.](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization)
+
+1. In the Okta Admin Console, navigate to **Security > API** in the left
+   sidebar.
+2. Click **Add Authorization Server**.
+3. Set the **Name** to something like "MCP Server Authorization".
+4. Set the **Audience** to the canonical URL of your MCP Server. For example, if
+   your MCP Server is hosted at `https://my-gateway.zuplo.dev/mcp`, then the
+   audience would be `https://my-gateway.zuplo.dev/mcp`. **The trailing slash is
+   not required.**
+5. Add a **Description** and click **Save**.
+
+Note the **Issuer Metadata URI** shown in the authorization server details.
+You'll need this for your Zuplo configuration.
+
+## Configure Scopes
+
+Next, you'll need to configure the scopes for your authorization server.
+
+1. In your authorization server settings, click the **Scopes** tab.
+2. Click **Add Scope**.
+3. Set the **Name** to something like `mcp:access`.
+4. Add a **Display phrase** and **Description** (like "Access to MCP Server
+   tools").
+5. Check **Set as a default scope** and click **Create**.
+
+## Create an OAuth Client Application
+
+Next, you'll need to create an OAuth client application for your MCP server.
+
+:::note
+
+Okta requires an admin API key for to dynamically register clients. This may not
+be well supported by MCP clients. However, MCP clients should also support an
+alternative way to obtain a client ID and client credential. This document
+assumes an MCP client can set these fields without having to dynamically
+register a client.
+
+:::
+
+1. In the Okta Admin Console, navigate to **Applications > Applications** in the
+   left sidebar.
+2. Click **Create App Integration**.
+3. Select **OIDC - OpenID Connect** as the sign-in method.
+4. Select **Web Application** as the application type and click **Next**.
+5. Set the **App integration name** to something like "MCP Client Application".
+6. For **Grant types**, check **Authorization Code** and **Refresh Token**.
+7. For **Sign-in redirect URIs**, leave this empty or set to a placeholder like
+   `http://localhost:3000/callback`.
+8. For **Controlled access**, select **Allow everyone in your organization to
+   access**.
+9. Click **Save**.
+
+After creating the application, note the **Client ID** and **Client Secret**
+from the application's **General** tab. You'll need these for your MCP client
+configuration.
+
+## Create a Default Policy and Rule
+
+You'll need to create an access policy for your authorization server.
+
+1. In your authorization server settings (found in **Security > API**) click the
+   **Access Policies** tab.
+2. Click **Add New Access Policy**.
+3. Set the **Name** to something like "MCP Client Access Policy".
+4. Add a **Description** and assign it to **All clients**.
+5. Click **Create Policy**.
+
+Now create a rule for this policy:
+
+1. Click **Add Rule** within your new policy.
+2. Set the **Rule Name** to something like "Allow MCP Access".
+3. In the **IF AND** section:
+   - **Grant type is**: Select the grant type. For the widest grant for all MCP
+     clients, select **Client Credentials**, **Authorization Code**, and
+     **Device Authorization** (???)
+   - **User is**: Select **Any user assigned the app**
+   - **Scopes requested**: Select **The following scopes** and choose the scope
+     you created for the authorization server (i.e., `mcp:access`)
+4. In the **THEN AND** section:
+   - **Use this inline hook**: None (disabled)
+   - **Access token lifetime is**: Set to desired value (e.g., 1 hour)
+   - **Refresh token lifetime is**: Set to desired value (e.g., 90 days)
+5. Click **Create Rule**.
+
+## Configure OAuth on Zuplo
+
+To set up your gateway to support OAuth authentication for your MCP Server, you
+will need to do the following:
+
+1. Create an Okta JWT Auth inbound policy on your MCP Server route. This policy
+   will need to have the option `"oAuthResourceMetadataEnabled": true` to enable
+   authorization resource metadata discovery.
+
+   ```json
+   {
+     "name": "mcp-okta-oauth-inbound",
+     "policyType": "okta-jwt-auth-inbound",
+     "handler": {
+       "export": "OktaJwtInboundPolicy",
+       "module": "$import(@zuplo/runtime)",
+       "options": {
+         "oAuthResourceMetadataEnabled": true,
+         "audience": "https://my-gateway.zuplo.dev/mcp",
+         "issuer": "https://your-okta-domain.okta.com/oauth2/your-auth-server-id"
+       }
+     }
+   }
+   ```
+
+   - Replace `my-gateway.zuplo.dev/mcp` with the audience you defined in your
+     authorization server.
+   - Replace `your-okta-domain` in the `issuer` field with your actual Okta
+     domain.
+   - Replace `your-auth-server-id` in the `issuer` field with the actual ID of
+     your Okta authorization server.
+
+2. Add the OAuth policy to the MCP Server route. For example:
+
+   ```json
+   "paths": {
+     "/mcp": {
+       "post": {
+         "x-zuplo-route": {
+
+           // etc. etc.
+           // other properties for the MCP server route handler
+
+           "policies": {
+             "inbound": [
+               "mcp-oauth-inbound"
+             ]
+           }
+         }
+       }
+     }
+   }
+   ```
+
+3. Add the `OAuthProtectedResourcePlugin` to your `runtimeInit` function in the
+   `modules/zuplo.runtime.ts` file:
+
+   ```ts
+   import {
+     RuntimeExtensions,
+     OAuthProtectedResourcePlugin,
+   } from "@zuplo/runtime";
+
+   export function runtimeInit(runtime: RuntimeExtensions) {
+     runtime.addPlugin(
+       new OAuthProtectedResourcePlugin({
+         authorizationServers: [
+           "https://your-okta-domain.okta.com/oauth2/your-auth-server-id",
+         ],
+         resourceName: "My MCP OAuth Resource",
+       }),
+     );
+   }
+   ```
+
+   - Replace `your-okta-domain` in the `issuer` field with your actual Okta
+     domain.
+   - Replace `your-auth-server-id` in the `issuer` field with the actual ID of
+     your Okta authorization server.
+
+   This plugin populates the `.well-known` routes for the MCP server auth
+   metadata discover. This enables MCP clients to automatically discover the
+   authorization issuer endpoint. See the
+   [OAuth Protected Resource Plugin docs](../programmable-api/oauth-protected-resource-plugin)
+   for more details on this runtime plugin.
+
+## Testing
+
+The [MCP Inspector](https://github.com/modelcontextprotocol/inspector) doesn't
+currently support setting an initial access token or presenting a UI for setting
+the client ID or secret.
+
+Refer to the [Manual OAuth MCP Testing](./manual-mcp-oauth-testing) guide for
+further instructions on testing your MCP server with `curl`.
+
+If you need more help debugging, see
+[Testing OAuth on Zuplo](../handlers/mcp-server.md#oauth-testing).

--- a/docs/articles/manual-mcp-oauth-testing.md
+++ b/docs/articles/manual-mcp-oauth-testing.md
@@ -1,0 +1,186 @@
+---
+title: Manual OAuth MCP Testing
+---
+
+MCP client OAuth support is evolving rapidly and many clients don't yet support
+the full flow for dynamic client registration, PKCE, initial tokens during DCR,
+etc.
+
+This guide shows you how you can use common tools like `curl` and `openssl` to
+manually test a configured authorization server and MCP server.
+
+## Existing auth server client ID and secret
+
+The following guide walks you through manually testing an OAuth provider with a
+client ID and secret configuration. This is also useful for debugging OAuth
+issues during authorization flows for MCP.
+
+### Prerequisites
+
+- `curl`, `jq`, and `openssl` installed on your system
+- An OAuth client ID and client Secret. For the purposes of demonstration, this
+  guide uses an Okta Application client ID and secret.
+
+### Testing Script
+
+Create a test script to verify your complete OAuth flow:
+
+```bash
+#!/bin/bash
+
+# OAuth 2.1 flow test Script for MCP with pre-configured client.
+# Based on MCP Authorization specification:
+# https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization
+
+set -e
+
+# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# !!!!!!! Configuration !!!!!!!!
+#
+# Update these values to your MCP server hosted on Zuplo and your auth provider
+# config values.
+
+MCP_ENDPOINT="https://your-gateway.zuplo.dev/mcp"
+CLIENT_ID="your-client-id"
+CLIENT_SECRET="your-client-secret"
+REDIRECT_URI="http://localhost:8080/authorization-code/callback"
+SCOPE="mcp:access"
+
+# !!!!! Configuration end !!!!!!
+# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+# Colors for pretty output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${BLUE}=== MCP OAuth 2.1 Testing ===${NC}"
+
+# Step 1: Discover OAuth configuration from MCP endpoint
+echo -e "${BLUE}Step 1: Discovering OAuth configuration...${NC}"
+MCP_RESPONSE=$(curl -s -i -X POST "${MCP_ENDPOINT}" \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc": "2.0", "id": "1", "method": "ping"}')
+
+# Extract resource metadata URL
+RESOURCE_METADATA_URL=$(echo "${MCP_RESPONSE}" | grep -i "resource_metadata=" | \
+  sed 's/.*resource_metadata=\([^[:space:]]*\).*/\1/' | tr -d '\r\n')
+
+echo "Resource metadata URL: ${RESOURCE_METADATA_URL}"
+
+# Step 2: Get authorization server info
+RESOURCE_METADATA=$(curl -s "${RESOURCE_METADATA_URL}")
+AUTH_SERVER_URL=$(echo "${RESOURCE_METADATA}" | jq -r '.authorization_servers[0]')
+
+echo "Authorization Server: ${AUTH_SERVER_URL}"
+
+# Step 3: Get OAuth endpoints
+OAUTH_METADATA=$(curl -s "${AUTH_SERVER_URL}/.well-known/oauth-authorization-server")
+AUTH_ENDPOINT=$(echo "${OAUTH_METADATA}" | jq -r '.authorization_endpoint')
+TOKEN_ENDPOINT=$(echo "${OAUTH_METADATA}" | jq -r '.token_endpoint')
+
+# Step 4: Generate PKCE parameters
+CODE_VERIFIER=$(openssl rand -base64 32 | tr '/+' '_-' | tr -d '=')
+CODE_CHALLENGE=$(echo -n "$CODE_VERIFIER" | openssl dgst -sha256 -binary | openssl base64 | tr '/+' '_-' | tr -d '=')
+STATE=$(openssl rand -hex 16)
+
+# Step 5: Build authorization URL
+AUTH_URL="${AUTH_ENDPOINT}?response_type=code&client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&scope=${SCOPE}&state=${STATE}&code_challenge=${CODE_CHALLENGE}&code_challenge_method=S256"
+
+echo -e "${YELLOW}Open this URL in your browser:${NC}"
+echo "${AUTH_URL}"
+echo
+echo -e "${YELLOW}After login, copy the authorization code from the callback URL${NC}"
+read -p "Enter the authorization code: " AUTH_CODE
+
+# Step 6: Exchange code for token
+TOKEN_RESPONSE=$(curl -s -X POST "${TOKEN_ENDPOINT}" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -u "${CLIENT_ID}:${CLIENT_SECRET}" \
+  -d "grant_type=authorization_code&code=${AUTH_CODE}&redirect_uri=${REDIRECT_URI}&code_verifier=${CODE_VERIFIER}")
+
+ACCESS_TOKEN=$(echo "${TOKEN_RESPONSE}" | jq -r '.access_token')
+
+if [[ "$ACCESS_TOKEN" == "null" ]]; then
+    echo -e "${RED}Token exchange failed:${NC}"
+    echo "${TOKEN_RESPONSE}" | jq .
+    exit 1
+fi
+
+echo -e "${GREEN}✓ Access token obtained${NC}"
+
+# Step 7: Test MCP endpoint with token
+MCP_AUTH_RESPONSE=$(curl -s -X POST "${MCP_ENDPOINT}" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc": "2.0", "id": "1", "method": "ping"}')
+
+echo -e "${GREEN}✓ MCP ping test:${NC}"
+echo "${MCP_AUTH_RESPONSE}" | jq .
+
+echo -e "${GREEN}=== OAuth flow test complete ===${NC}"
+```
+
+### Running the Test
+
+1. **Update the configuration** at the top of the script with your values:
+   - `MCP_ENDPOINT`: Your Zuplo gateway MCP endpoint
+   - `CLIENT_ID`: The ID of the client or application for the auth server
+   - `CLIENT_SECRET`: The secret for the client or application for the auth
+     server
+   - `REDIRECT_URI`: Typically, must match exactly what's configured in your
+     auth server's redirect
+
+2. **Make the script executable**: `chmod +x test-oauth.sh`
+
+3. **Run the script**: `./test-oauth.sh`
+
+4. **Follow the prompts**:
+   - Open the authorization URL in your browser from the terminal output
+   - Complete the login flow
+   - Copy the authorization code from the callback URL. It will look something
+     like:
+
+   ```
+   http://localhost:8080/authorization-code/callback?code=ABC123&state=XYZ987
+   ```
+
+   - Paste just the code part into the script
+
+   :::warning
+
+   This script does **not** include a web server and does **not** support
+   dynamically extracting the authorization callback code. You must manually
+   grab the code from the query parameter and enter it into the terminal prompt.
+
+   :::
+
+### Common Issues and Troubleshooting
+
+**"Policy evaluation failed"**: Check that your client has:
+
+- Correct redirect URI configured
+- Correct scope assigned and configured
+- Authorization code grant enabled
+- Proper access policies and rules
+
+**"Invalid client" errors**: Verify your Client ID and Client Secret are
+correct.
+
+**"Invalid redirect URI"**: The redirect URI configured in the script may need
+to exactly match what's configured in your authorization server and client.
+
+**Browser redirects immediately without login**: You may already be logged into
+your auth provider or an existing session exists. To log in from a clean state,
+try the following:
+
+- Log out from your authorization provider
+- Clear browser cookies, sessions, and caches
+- Using an incognito/private browser window
+
+**Token exchange fails**: Check that:
+
+- PKCE is enabled for your client
+- The authorization code hasn't expired (use it immediately)

--- a/sidebar.ts
+++ b/sidebar.ts
@@ -226,6 +226,8 @@ export const docs: Navigation = [
       "articles/non-standard-ports",
       "articles/convert-urls-to-openapi",
       "articles/configuring-auth0-for-mcp-auth",
+      "articles/configuring-okta-for-mcp-auth",
+      "articles/manual-mcp-oauth-testing",
     ],
   },
   {


### PR DESCRIPTION
* Okta MCP auth server docs - note: unfortunately, Okta doesn't support DCR without an admin token or initial access token so testing through the MCP inspector is not well supported: (see https://github.com/modelcontextprotocol/inspector/issues/683)
* Doc for manually testing MCP Oauth flows using `curl` and `openssl`

Closes ZUP-4901
Related to ZUP-4868