### PR TITLE
chore: Refactor MCP custom tooling docs

### DIFF
--- a/docs/ai/mcp.mdx
+++ b/docs/ai/mcp.mdx
@@ -125,16 +125,17 @@ When exposing routes as MCP tools:
 ### 2. MCP Custom Tools: Programmable AI Tools
 
 For more complex scenarios, use MCP Custom Tools to create sophisticated AI
-tools with custom business logic, multi-step workflows, and programmatic
-control.
+tools with custom business logic, multi-step workflows, and programmatic control
+using OpenAPI specifications and custom handler functions.
 
 #### Key Features
 
+- **OpenAPI Standard**: Define tools using standard OpenAPI 3.1 specifications
 - **Custom Logic**: Implement complex business workflows that go beyond simple
   API calls to enable powerful AI workloads
 - **Multi-Step Operations**: Chain multiple API calls, data transformations, and
   conditional logic
-- **Type Safety**: Built-in Zod schema validation for inputs and outputs
+- **Type Safety**: Built-in JSON Schema validation for inputs and outputs
 - **Runtime Integration**: Full access to your gateway through
   `context.invokeRoute()`
 
@@ -146,58 +147,89 @@ manually, this workflow can be used as a single "aggregate" process to validate
 the provided customer, check that items are in stock, determine pricing, and
 place orders for those items.
 
+**OpenAPI Tool Definition:**
+
+```json
+{
+  "/process-order": {
+    "post": {
+      "summary": "Process customer order",
+      "description": "Process a customer order with inventory validation and pricing",
+      "operationId": "processCustomerOrder",
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": ["customerId", "orderNum"],
+              "properties": {
+                "customerId": {
+                  "type": "string",
+                  "description": "Unique customer identifier"
+                },
+                "orderNum": {
+                  "type": "number",
+                  "description": "Order number to process"
+                }
+              }
+            }
+          }
+        }
+      },
+      "x-zuplo-route": {
+        "handler": {
+          "export": "default",
+          "module": "$import(./modules/process-order)"
+        }
+      }
+    }
+  }
+}
+```
+
+**Custom Handler Implementation:**
+
 ```typescript
-const mcpSdk = new McpCustomToolsSDK();
+// modules/process-order.ts
+import { ZuploContext, ZuploRequest } from "@zuplo/runtime";
 
-const checkCustomerOrder = mcpSdk.defineTool({
-  // The name of the tool that an MCP client can call
-  name: "process_customer_order",
+export default async function (request: ZuploRequest, context: ZuploContext) {
+  const args = await request.json();
 
-  // The meaningful description provided to an MCP client's LLM for tool selection
-  description: "Process a customer order with inventory validation and pricing",
+  // 1. Validate customer exists and is active
+  const customerRes = await context.invokeRoute(
+    `/customers/${args.customerId}`,
+  );
+  if (!customerRes.ok) {
+    throw new Error("Customer not found or inactive");
+  }
+  const customer = await customerRes.json();
 
-  // The schea that is used to validate incoming arguments from MCP client tool calls
-  inputSchema: z.object({
-    customerId: z.string(),
-    orderNum: z.number(),
-  }),
+  // 2. Check the customer's order
+  const orderResponse = await context.invokeRoute(`/orders/${args.orderNum}`);
 
-  // The actual code that is invoked when a tool is called and the JSON arguments
-  // are validated. The tool's type-checked arguments and the ZuploContext
-  // are passed through.
-  handler: async (args, context) => {
-    // 1. Validate customer exists and is active
-    const customerRes = await context.invokeRoute(
-      `/customers/${args.customerId}`,
-    );
-    if (!customerRes.ok) {
-      return mcpSdk.errorResponse("Customer not found or inactive");
-    }
-    const customer = await customerRes.json();
+  if (!orderResponse.ok) {
+    throw new Error("Order not found");
+  }
+  const order = await orderResponse.json();
 
-    // 2. Check the customers order
-    const orderResponse = await context.invokeRoute(`/orders/${args.orderNum}`);
-
-    if (!orderResponse.ok) {
-      const error = await orderResponse.text();
-      return mcpSdk.errorResponse("Order not found");
-    }
-    const order = await orderResponse.json();
-
-    // 3. Response to MCP client with JSON response
-    return mcpSdk.jsonResponse({
-      orderNum: orderResponse.id,
-      items: orderResponse.items,
-    });
-  },
-});
+  // 3. Return structured response
+  return {
+    orderNum: order.id,
+    items: order.items,
+    status: "processed",
+    customerId: args.customerId,
+  };
+}
 ```
 
 #### Getting Started with Custom Tools
 
-1. Create custom tool definitions using the SDK
-2. Configure tools in the MCP Server Handler
-3. Deploy and test with MCP clients
+1. Create an OpenAPI specification defining your tools as POST endpoints
+2. Implement custom handler functions for complex business logic
+3. Configure the MCP Server Handler with your OpenAPI specification
+4. Deploy and test with MCP clients
 
 [Read the full documentation on MCP Custom Tools](/docs/handlers/mcp-server-custom-tools)
 

--- a/docs/handlers/mcp-server-custom-tools.mdx
+++ b/docs/handlers/mcp-server-custom-tools.mdx
@@ -122,7 +122,7 @@ Create an OpenAPI specification that defines your tools:
 
 :::tip
 
-`POST` routes with a `requestBody` and a defined `schema` is translated into an
+`POST` routes with a `requestBody` and a defined `schema` are translated into an
 MCP tool's parameters. When invoked, these are validated by the MCP server to
 ensure the tool is being correctly used by the LLM.
 

--- a/docs/handlers/mcp-server-custom-tools.mdx
+++ b/docs/handlers/mcp-server-custom-tools.mdx
@@ -6,82 +6,179 @@ sidebar_label: Custom Tools
 The MCP Server Handler supports custom tools that allow you to create
 sophisticated MCP
 ([Model Context Protocol](https://modelcontextprotocol.io/introduction)) tools
-using code rather than simple 1:1 OpenAPI route mappings. This provides the
+using OpenAPI specifications and custom handler functions. This provides the
 flexibility to build complex workflows that can invoke multiple API routes,
-implement custom business logic, and provide rich responses to AI systems.
+implement custom business logic, and provide rich responses to AI systems
+without having to sacrifice the governance and power of an OpenAPI config.
 
 :::tip
 
-Custom tools give you full programmatic control over tool behavior within the
-[MCP Server Handler](./mcp-server.mdx). This is more flexible than automatic
-OpenAPI route transformation, allowing complex multi-step workflows and custom
-logic.
+Custom tools give you full programmatic control over tool behavior within an
+[MCP Server Handler](./mcp-server.mdx). Define tools using standard OpenAPI
+patterns with custom TypeScript handlers for complex multi-step workflows and
+custom logic.
 
 :::
 
 ## Key Features
 
-- **Programmatic Control**: Define tools using TypeScript with full access to
-  Zuplo's runtime
+- **OpenAPI Standard**: Define tools using standard OpenAPI specifications
+- **Custom Handlers**: Implement complex logic using TypeScript functions
 - **Complex Workflows**: Chain multiple API calls, implement business logic, and
   handle complex data transformations
-- **Type Safety**: Built-in Zod schema validation for inputs and outputs
+- **Type Safety**: Built-in JSON Schema validation for LLM tool arguments and
+  inputs
 - **Runtime Integration**: Access to `context.invokeRoute()`, logging, and other
   Zuplo runtime features
 
 ## Quick Start
 
-### 1. Create Your Custom Tools Module
+### 1. Define Your API Specification
 
-Create a module that defines your custom MCP tools:
+Create an OpenAPI specification that defines your tools:
 
-```typescript
-// modules/mcp-tools.ts
-import { McpCustomToolsSDK, McpToolDefinition } from "@zuplo/runtime";
-import { z } from "zod/v4";
-
-// Initialize the SDK
-const mcpSdk = new McpCustomToolsSDK();
-
-// Define a tool
-const addNumbersTool: McpToolDefinition = mcpSdk.defineTool({
-  name: "add_numbers",
-  description: "Adds two numbers together and returns the result",
-  schema: z.object({
-    a: z.number().describe("First number to add"),
-    b: z.number().describe("Second number to add"),
-  }),
-  handler: async (args, context) => {
-    context.log.info(`Adding ${args.a} + ${args.b}`);
-    const result = args.a + args.b;
-    return mcpSdk.textResponse(`${args.a} + ${args.b} = ${result}`);
+```json
+{
+  "openapi": "3.1.0",
+  "info": {
+    "version": "0.0.1",
+    "title": "My Calculator API",
+    "description": "A simple calculator API with basic arithmetic operations"
   },
-});
-
-// Make a "default" export for all tools as an array of McpToolDefinitions
-const allTools: McpToolDefinition[] = [addNumbersTool];
-
-export default allTools;
+  "paths": {
+    "/add": {
+      "post": {
+        "summary": "Add two numbers",
+        "description": "Adds two numbers together and returns the result",
+        "operationId": "addNumbers",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TwoNumberOperation"
+              }
+            }
+          }
+        },
+        "x-zuplo-route": {
+          "corsPolicy": "none",
+          "handler": {
+            "export": "default",
+            "module": "$import(./modules/add)"
+          }
+        }
+      }
+    },
+    "/multiply": {
+      "post": {
+        "summary": "Multiply two numbers",
+        "description": "Multiplies two numbers together and returns the result",
+        "operationId": "multiplyNumbers",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TwoNumberOperation"
+              }
+            }
+          }
+        },
+        "x-zuplo-route": {
+          "corsPolicy": "none",
+          "handler": {
+            "export": "default",
+            "module": "$import(./modules/multiply)"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "TwoNumberOperation": {
+        "type": "object",
+        "required": ["a", "b"],
+        "properties": {
+          "a": {
+            "type": "number",
+            "description": "First number"
+          },
+          "b": {
+            "type": "number",
+            "description": "Second number"
+          }
+        },
+        "example": {
+          "a": 10,
+          "b": 5
+        }
+      }
+    }
+  }
+}
 ```
 
-### 2. Configure the MCP Server Handler
+:::tip
 
-Add the custom tools to your MCP Server Handler in **routes.oas.json**:
+`POST` routes with a `requestBody` and a defined `schema` is translated into an
+MCP tool's parameters. When invoked, these are validated by the MCP server to
+ensure the tool is being correctly used by the LLM.
+
+Other methods like `GET`, `DELETE`, etc. work in a similar fashion in order to
+support complex tools in the shape of your APIs.
+
+:::
+
+### 2. Create Custom Handler Functions
+
+Create handler modules for your tools that map to your routes:
+
+```typescript
+// modules/add.ts
+import { ZuploContext, ZuploRequest } from "@zuplo/runtime";
+
+export default async function (request: ZuploRequest, context: ZuploContext) {
+  const args = await request.json();
+  context.log.info(`Adding ${args.a} + ${args.b}`);
+  return args.a + args.b;
+}
+```
+
+```typescript
+// modules/multiply.ts
+import { ZuploContext, ZuploRequest } from "@zuplo/runtime";
+
+export default async function (request: ZuploRequest, context: ZuploContext) {
+  const args = await request.json();
+  context.log.info(`Multiplying ${args.a} * ${args.b}`);
+  return args.a * args.b;
+}
+```
+
+### 3. Configure the MCP Server Handler
+
+Configure the MCP Server Handler to use your OpenAPI specification:
 
 ```json
 {
   "paths": {
     "/mcp": {
       "post": {
-        "operationId": "mcp-custom-tools-handler",
+        "operationId": "mcp-server-handler",
         "x-zuplo-route": {
           "handler": {
             "export": "mcpServerHandler",
             "module": "$import(@zuplo/runtime)",
             "options": {
-              "name": "Custom Tools MCP Server",
+              "name": "Calculator MCP Server",
               "version": "0.0.0",
-              "customTools": "$import(./modules/mcp-tools)"
+              "openApiFilePaths": [
+                {
+                  "filePath": "./config/routes.oas.json"
+                }
+              ]
             }
           }
         }
@@ -91,7 +188,7 @@ Add the custom tools to your MCP Server Handler in **routes.oas.json**:
 }
 ```
 
-### 3. Deploy and Test
+### 4. Deploy and Test
 
 Deploy your project and test your MCP server:
 
@@ -106,103 +203,186 @@ curl https://your-gateway.zuplo.dev/mcp \
   -d '{ "jsonrpc": "2.0", "id": "0", "method": "tools/list" }'
 ```
 
-## SDK Reference
-
-### `McpCustomToolsSDK`
-
-The main SDK class providing helper methods for creating tools and responses.
-
-#### Methods
-
-**`defineTool(config)`** Define a tool with a configuration object.
-
-**Response Helpers:**
-
-- `textResponse(text: string)` - Create a text response
-- `jsonResponse(data: any)` - Create a JSON response with structured content
-- `errorResponse(message: string)` - Create an error response
-- `imageResponse(data: string, mimeType: string)` - Create an image response
-- `resourceResponse(uri: string, mimeType?: string)` - Create a resource
-  response
-- `getInvokeHeaders()` - Access original MCP request headers
-
-### Handler Configuration
-
-The `customTools` option in the MCP Server Handler expects:
-
-- **Default Export**: Your module must export an array of `McpToolDefinition` as
-  the default export
-- **Tool Names**: Must be unique across all tools (server won't build if names
-  clash)
-- **Array Format**: Tools must be exported as an array, not individual exports
-
 ## Advanced Usage
 
-### Output Schema Validation
+### Complex Multi-Step Workflows
 
-Starting with `2025-06-18`, MCP clients may support validating the output of
-tool calls from servers based on a provided `outputSchema`:
+Create sophisticated workflows that chain multiple operations:
 
 ```typescript
-const weatherTool: McpToolDefinition = mcpSdk.defineTool({
-  name: "get_weather",
-  description: "Get current weather for a location",
-  schema: z.object({
-    location: z.string().describe("City name or coordinates"),
-  }),
-  outputSchema: z.object({
-    temperature: z.number(),
-    condition: z.string(),
-    humidity: z.number(),
-  }),
-  handler: async (args, context) => {
-    const weatherResp = await context.invokeRoute(
-      `/weather?location=${args.location}`,
-    );
-    const weather = await weatherResp.json();
+// modules/process-order.ts
+import { ZuploContext, ZuploRequest } from "@zuplo/runtime";
 
-    return mcpSdk.jsonResponse({
-      temperature: weather.temp,
-      condition: weather.conditions,
-      humidity: weather.humidity,
-    });
-  },
-});
+export default async function (request: ZuploRequest, context: ZuploContext) {
+  const args = await request.json();
+
+  // Step 1: Validate customer
+  const customerResp = await context.invokeRoute(
+    `/customers/${args.customerId}`,
+  );
+  if (!customerResp.ok) {
+    throw new Error("Customer not found");
+  }
+
+  // Step 2: Check inventory
+  const inventoryChecks = await Promise.all(
+    args.items.map((item: any) =>
+      context.invokeRoute(
+        `/inventory/${item.productId}/check?quantity=${item.quantity}`,
+      ),
+    ),
+  );
+
+  const unavailableItems = inventoryChecks
+    .map((resp, i) => ({ resp, item: args.items[i] }))
+    .filter(({ resp }) => !resp.ok)
+    .map(({ item }) => item.productId);
+
+  if (unavailableItems.length > 0) {
+    throw new Error(`Items not available: ${unavailableItems.join(", ")}`);
+  }
+
+  // Step 3: Create order
+  const orderResp = await context.invokeRoute("/orders", {
+    method: "POST",
+    body: JSON.stringify({
+      customerId: args.customerId,
+      items: args.items,
+    }),
+    headers: { "Content-Type": "application/json" },
+  });
+
+  const order = await orderResp.json();
+
+  return {
+    orderId: order.id,
+    status: "created",
+    total: order.total,
+    estimatedDelivery: order.estimatedDelivery,
+  };
+}
+```
+
+With the corresponding OpenAPI definition:
+
+```json
+{
+  "/process-order": {
+    "post": {
+      "summary": "Process a customer order",
+      "description": "Process a customer order through multiple validation steps",
+      "operationId": "processOrder",
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": ["customerId", "items"],
+              "properties": {
+                "customerId": {
+                  "type": "string",
+                  "description": "Unique customer identifier"
+                },
+                "items": {
+                  "type": "array",
+                  "description": "List of items to order",
+                  "items": {
+                    "type": "object",
+                    "required": ["productId", "quantity"],
+                    "properties": {
+                      "productId": {
+                        "type": "string",
+                        "description": "Product identifier"
+                      },
+                      "quantity": {
+                        "type": "number",
+                        "description": "Number of items to order"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "Order processed successfully",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "orderId": {
+                    "type": "string",
+                    "description": "Generated order ID"
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": ["created", "pending", "confirmed"],
+                    "description": "Order status"
+                  },
+                  "total": {
+                    "type": "number",
+                    "description": "Total amount"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "x-zuplo-route": {
+        "handler": {
+          "export": "default",
+          "module": "$import(./modules/process-order)"
+        }
+      }
+    }
+  }
+}
 ```
 
 ### Error Handling
 
-For more ergonomic and AI friendly error handling, utilize the `errorResponse`
-helper. This wraps the JSON RPC 2.0 for raising errors.
-
-For example, the following tool will raise an error if the caller selects
-`shouldFail`:
+Handle errors gracefully by throwing standard JavaScript errors:
 
 ```typescript
-const errorHandlingTool: McpToolDefinition = mcpSdk.defineTool({
-  name: "test_error_handling",
-  description: "Tests error handling capabilities",
-  schema: z.object({
-    shouldFail: z.boolean().default(false),
-    errorMessage: z.string().optional(),
-  }),
-  handler: async (args) => {
-    if (args.shouldFail) {
-      return mcpSdk.errorResponse(
-        args.errorMessage || "Intentional test error",
-      );
-    }
+// modules/validate-user.ts
+import { ZuploContext, ZuploRequest } from "@zuplo/runtime";
 
-    return mcpSdk.textResponse("Success! No error occurred.");
-  },
-});
+export default async function (request: ZuploRequest, context: ZuploContext) {
+  const args = await request.json();
+
+  if (args.shouldFail) {
+    throw new Error(args.errorMessage || "Validation failed");
+  }
+
+  return { valid: true, userId: args.userId };
+}
 ```
 
-### Multi-Step Workflow Tool
+### Accessing Request Headers
 
-Using the ZuploContext `invokeRoute`, you can create powerful aggregate
-workflows that call multiple routes on your gateway. This works by re-invoking
-routes on your gateway _without_ having to go back out to HTTP.
+Access original request headers through the standard request object:
+
+```typescript
+// modules/check-headers.ts
+import { ZuploContext, ZuploRequest } from "@zuplo/runtime";
+
+export default async function (request: ZuploRequest, context: ZuploContext) {
+  const args = await request.json();
+  const headerValue = request.headers.get(args.headerName);
+
+  if (headerValue) {
+    return `Header '${args.headerName}': ${headerValue}`;
+  } else {
+    return `Header '${args.headerName}' not found`;
+  }
+}
+```
 
 :::note
 
@@ -212,100 +392,6 @@ invoked alongside policies that are associated with any calls made through
 `invokeRoute`.
 
 :::
-
-```typescript
-const orderProcessingTool: McpToolDefinition = mcpSdk.defineTool({
-  name: "process_order",
-  description: "Process a customer order through multiple steps",
-  schema: z.object({
-    customerId: z.string(),
-    items: z.array(
-      z.object({
-        productId: z.string(),
-        quantity: z.number(),
-      }),
-    ),
-  }),
-  handler: async (args, context) => {
-    // Step 1: Validate customer
-    const customerResp = await context.invokeRoute(
-      `/customers/${args.customerId}`,
-    );
-    if (!customerResp.ok) {
-      return mcpSdk.errorResponse("Customer not found");
-    }
-
-    // Step 2: Check inventory
-    const inventoryChecks = await Promise.all(
-      args.items.map((item) =>
-        context.invokeRoute(
-          `/inventory/${item.productId}/check?quantity=${item.quantity}`,
-        ),
-      ),
-    );
-
-    const unavailableItems = inventoryChecks
-      .map((resp, i) => ({ resp, item: args.items[i] }))
-      .filter(({ resp }) => !resp.ok)
-      .map(({ item }) => item.productId);
-
-    if (unavailableItems.length > 0) {
-      return mcpSdk.errorResponse(
-        `Items not available: ${unavailableItems.join(", ")}`,
-      );
-    }
-
-    // Step 3: Create order
-    const orderResp = await context.invokeRoute("/orders", {
-      method: "POST",
-      body: JSON.stringify({
-        customerId: args.customerId,
-        items: args.items,
-      }),
-      headers: { "Content-Type": "application/json" },
-    });
-
-    const order = await orderResp.json();
-
-    return mcpSdk.jsonResponse({
-      orderId: order.id,
-      status: "created",
-      total: order.total,
-      estimatedDelivery: order.estimatedDelivery,
-    });
-  },
-});
-```
-
-### Request Headers
-
-You can access the original MCP request headers using the SDK and the
-`getInvokeHeaders` method. This is especially useful if a tool uses
-`context.invokeRoute` and headers need to be passed through to your downstream
-request.
-
-For example, this tool gets the original headers via `getInvokeHeaders` and
-returns the provided as an argument in `headerName`.
-
-```typescript
-const headerAccessTool: McpToolDefinition = mcpSdk.defineTool({
-  name: "check_headers",
-  description: "Demonstrates access to original MCP request headers",
-  schema: z.object({
-    headerName: z.string().describe("Specific header name to check"),
-  }),
-  handler: async (args) => {
-    const headers = mcpSdk.getInvokeHeaders();
-    if (headers[args.headerName]) {
-      return mcpSdk.textResponse(
-        `Header '${args.headerName}': ${headers[args.headerName]}`,
-      );
-    } else {
-      return mcpSdk.textResponse(`Header '${args.headerName}' not found`);
-    }
-  },
-});
-```
 
 ## Testing Custom Tools
 
@@ -346,7 +432,7 @@ curl https://your-gateway.zuplo.dev/mcp \
     "id": "1",
     "method": "tools/call",
     "params": {
-      "name": "add_numbers",
+      "name": "addNumbers",
       "arguments": {
         "a": 5,
         "b": 3
@@ -357,56 +443,58 @@ curl https://your-gateway.zuplo.dev/mcp \
 
 ## Best Practices
 
-### Input Validation
+### Schema Design
 
-Use a well structured and defined Zod schema with the `schema` param. This is
-used by the server to validate MCP client inputs (i.e., JSON generated by an
-LLM). Providing descriptive schemas ensures an MCP Client's LLM always has the
-appropriate context on exactly _what_ arguments to provide to tools and can
+Use descriptive and well-structured JSON schemas for your tools. This is used by
+the server to validate MCP client inputs (i.e., JSON generated by an LLM).
+Providing descriptive schemas ensures an MCP Client's LLM always has the
+appropriate context on exactly what arguments to provide to tools and can
 dramatically reduce invalid tool usage. This validation is done automatically.
 
-The `args` passed to your handler assume the type of the object inferred by
-`schema`.
+```json
+// Good! Uses descriptive names and specific types with limiters and formats.
+{
+  "type": "object",
+  "required": ["userId"],
+  "properties": {
+    "userId": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Valid UUID for user ID"
+    },
+    "amount": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 10000,
+      "description": "Amount in cents"
+    }
+  }
+}
+```
 
-```typescript
-// Good! Uses descriptive names and specific types
-schema: z.object({
-  userId: z.string().uuid().describe("Valid UUID for user ID"),
-  amount: z.number().positive().max(10000).describe("Amount in cents"),
-});
-
+```json
 // Bad! Confusing. What is "a"? What is "b"? An LLM won't understand this.
-schema: z.object({
-  a: z.string(),
-  b: z.number(),
-});
-
-// Good! Descriptive nested items and well-structured
-schema: z.object({
-  customerId: z.uuid().describe("UUID of the customer"),
-  orderType: z.enum(["standard", "express", "overnight"]).describe("Delivery speed"),
-  items: z.array(z.object({
-    productId: z.string().describe("Product SKU or ID"),
-    quantity: z.number().int().positive().describe("Number of items"),
-  })).min(1).describe("List of items to order"),
-}),
-
-// Good! Output schema for structured responses using enums
-outputSchema: z.object({
-  orderId: z.string().describe("Generated order ID"),
-  total: z.number().describe("Total amount in cents"),
-  status: z.enum(["pending", "confirmed", "failed"]).describe("Order status"),
-})
+{
+  "type": "object",
+  "required": ["userId"],
+  "properties": {
+    "a": {
+      "type": "string"
+    },
+    "b": {
+      "type": "number"
+    }
+  }
+}
 ```
 
 ### Tool Design
 
-1. **Clear Names**: Use descriptive, action-oriented names (`get_user_profile`,
-   `create_order`)
+1. **Clear Operation IDs**: Use descriptive, action-oriented operation IDs
+   (`addNumbers`, `processOrder`)
 2. **Detailed Descriptions**: Help AI systems understand what your tool does
-3. **Error Handling**: Provide meaningful error messages
-4. **Avoid Name Clashes**: Ensure tool names are unique (server won't build
-   otherwise)
+3. **Error Handling**: Throw meaningful JavaScript errors
+4. **Unique Names**: Ensure operation IDs are unique across your API
 
 ## Troubleshooting
 
@@ -414,30 +502,24 @@ outputSchema: z.object({
 
 **Tool not appearing in `tools/list`:**
 
-- Check tool name for duplicates (server won't build with name clashes)
-- Verify tool is included in the default export array
-- Check that the module exports an array as default export
-- Check for validation errors in handler configuration or relevant logs
-
-**Server won't build:**
-
-- Check for tool name conflicts across all tools
-- Verify the module has a proper default export of type `McpToolDefinition[]`
-- Check TypeScript compilation errors in your tools module
-
-**Schema validation errors:**
-
-- Ensure Zod schemas are properly defined and aligned with expected tool handler
-  usage
-- Check that handler arguments match schema types
-- Verify output matches `outputSchema` if defined
+- Check that the endpoint is a POST method in your OpenAPI spec
+- Verify the operation has an `operationId`
+- Check for validation errors in your OpenAPI specification
+- Ensure the handler module exports a default function
 
 **Handler execution failures:**
 
-- Apply logs using `context.log.error()`, `context.log.warn()`,
-  `context.log.info()`, etc.
+- Use `context.log.error()`, `context.log.warn()`, `context.log.info()` for
+  logging
 - Verify API routes being invoked through `invokeRoute` exist and are accessible
 - Test individual API calls outside the MCP context
+- Check that your handler function is properly exported as default
+
+**Schema validation errors:**
+
+- Ensure JSON schemas are properly defined in the OpenAPI spec
+- Check that request body schemas match the data your handler expects
+- Verify response schemas match the data your handler returns
 
 ### Debugging Tips
 
@@ -446,6 +528,8 @@ outputSchema: z.object({
 2. **Test Components Separately**: Test API routes and business logic
    independently
 3. **Use MCP Inspector**: Interactive testing is invaluable for development
+4. **Validate OpenAPI**: Use tools like Swagger Editor to validate your OpenAPI
+   specification
 
 ## Learn More
 

--- a/docs/handlers/mcp-server.mdx
+++ b/docs/handlers/mcp-server.mdx
@@ -110,7 +110,7 @@ compatibility issues with your MCP client, ensure your `outputSchema` is a valid
 
 ### OpenAPI Routes to MCP Tools
 
-There are two options for configuring which API routes become MCP tools:
+There are three options for configuring MCP tools:
 
 #### Option 1: Transform Entire OpenAPI Files
 
@@ -192,6 +192,38 @@ Add specific routes as MCP tools using the `openApiTools` array. Specify
   setting for this specific route
 - `includeStructuredContent` (optional): Override the global
   `includeStructuredContent` setting for this specific route
+
+#### Option 3: Custom Tools with OpenAPI Specification
+
+Create custom tools with full programmatic control using a dedicated OpenAPI
+specifications and custom handler functions.
+
+This approach provides maximum flexibility for complex workflows:
+
+```json
+"paths": {
+  "/mcp": {
+    "post": {
+      "x-zuplo-route": {
+        "handler": {
+          "export": "mcpServerHandler",
+          "module": "$import(@zuplo/runtime)",
+          "options": {
+            "name": "Calculator MCP Server",
+            "version": "0.0.0",
+            "openApiSpec": "$import(./calculator-api.json)"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+With this approach, you define tools in a separate OpenAPI specification where
+each endpoint becomes an MCP tool with custom TypeScript handlers. See
+[MCP Server Custom Tools](./mcp-server-custom-tools.mdx) for detailed
+documentation.
 
 ### Tool names and descriptions
 


### PR DESCRIPTION
Refactors the MCP custom tooling to remove the in-code SDK in favor of the OpenAPI method of building custom tools.