### PR TITLE
Update local development instructions

### DIFF
--- a/docs/articles/local-development.mdx
+++ b/docs/articles/local-development.mdx
@@ -25,7 +25,6 @@ development purposes using your favorite code editor.
 
    ```bash title="Expected output: "
    cd <your-new-project-directory>
-   npm install
    npm run dev
    ```
 


### PR DESCRIPTION
Removed 'npm install' command from local development instructions.

Not necessary to do again.