### PR TITLE
Update project creation instructions in setup guide

### DIFF
--- a/docs/articles/step-1-setup-basic-gateway.mdx
+++ b/docs/articles/step-1-setup-basic-gateway.mdx
@@ -19,7 +19,8 @@ Note - Zuplo also supports building and running your API locally. To learn more
 1. **Sign-in**
 
    Sign in to [portal.zuplo.com](https://portal.zuplo.com) and create a free
-   account. Create a new **empty** project. Then...
+   account. Create a new **empty** project (don't import an existing project,
+   we'll setup git later). Then...
 
 1. Add your first **Route**
 


### PR DESCRIPTION
Clarify instructions for creating a new project by specifying not to import an existing project.