### PR TITLE
Refactor import statements in plugin-hydrolix-traffic-peak

### DIFF
--- a/docs/articles/plugin-hydrolix-traffic-peak.mdx
+++ b/docs/articles/plugin-hydrolix-traffic-peak.mdx
@@ -73,7 +73,7 @@ import {
   environment,
   HydrolixDefaultEntry,
   HydrolixRequestLoggerPlugin,
-  RuntimeExtensions
+  RuntimeExtensions,
 } from "@zuplo/runtime";
 
 export function runtimeInit(runtime: RuntimeExtensions) {


### PR DESCRIPTION
Removed redundant import statements for clarity.