### PR TITLE
Fix Stepper list formatting in default API key doc

### DIFF
--- a/docs/articles/accounts/default-api-key.mdx
+++ b/docs/articles/accounts/default-api-key.mdx
@@ -21,10 +21,11 @@ the default API key, your legacy developer portal will IMMEDIATELY stop working.
 
 To delete the default API key, follow these steps:
 
+{/* prettier-ignore */}
 <Stepper>
-  1. Navigate to your Zuplo account settings. 2. Click on the **API Keys**
-  section. 3. Locate the default API key in the list. It will be labeled
-  "Default consumer for account-name" and have a "default" tag. 4. Click the
-  **Delete** button next to the default API key. 5. Confirm the deletion when
-  prompted.
+1. Navigate to your Zuplo account settings.
+2. Click on the **API Keys** section.
+3. Locate the default API key in the list. It will be labeled "Default consumer for account-name" and have a "default" tag.
+4. Click the **Delete** button next to the default API key.
+5. Confirm the deletion when prompted.
 </Stepper>


### PR DESCRIPTION
## Summary
- Prettier was collapsing the numbered list inside the `<Stepper>` component into a single paragraph, causing all steps to render as one block of text
- Added `prettier-ignore` and put each step on its own line so they render correctly

## Test plan
- [ ] Verify the steps render as individual list items on the default API key doc page

🤖 Generated with [Claude Code](https://claude.com/claude-code)