### PR TITLE
Replace GH_NPM_PACKAGE_READ_TOKEN with GITHUB_TOKEN

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ registries:
   npm-github:
     type: npm-registry
     url: https://npm.pkg.github.com
-    token: ${{secrets.GH_NPM_PACKAGE_READ_TOKEN}}
+    token: ${{secrets.GITHUB_TOKEN}}
 updates:
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary
- Replaces `GH_NPM_PACKAGE_READ_TOKEN` PAT with native `GITHUB_TOKEN` for npm package access
- Private `@zuplo/*` packages now grant Actions access to consuming repos directly via GitHub's package permissions

## Changes
- **Workflow files**: `${{ secrets.GH_NPM_PACKAGE_READ_TOKEN }}` → `${{ github.token }}`
- **Dependabot files**: `${{ secrets.GH_NPM_PACKAGE_READ_TOKEN }}` → `${{ secrets.GITHUB_TOKEN }}`

## Test plan
- [ ] CI passes with the new token configuration
- [ ] Private `@zuplo/*` packages install successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)