### PR TITLE
claude/add-markdown-alternate-links-mQ30U

### DIFF
--- a/zudoku.config.tsx
+++ b/zudoku.config.tsx
@@ -15,6 +15,13 @@ const inkeepMetadataPlugin: ZudokuPlugin = {
   },
 };
 
+const markdownAlternatePlugin: ZudokuPlugin = {
+  getHead: ({ location }) => {
+    const mdHref = `/docs${location.pathname === "/" ? "" : location.pathname}.md`;
+    return <link rel="alternate" type="text/markdown" href={mdHref} />;
+  },
+};
+
 const config: ZudokuConfig = {
   basePath: "/docs",
   canonicalUrlOrigin: "https://zuplo.com",
@@ -53,6 +60,7 @@ const config: ZudokuConfig = {
   },
   plugins: [
     inkeepMetadataPlugin,
+    markdownAlternatePlugin,
     {
       getHead: () => (
         <>


### PR DESCRIPTION
Adds a Zudoku plugin that injects <link rel="alternate" type="text/markdown">
into the <head> of every page, pointing to the published .md version.
This helps LLMs discover and use the markdown version of documentation pages.

https://claude.ai/code/session_01RVLgnSAjeMhzVSqH2v2Ddp