### PR TITLE
Add Linux-only platform support notice to tunnel docs

### DIFF
--- a/docs/articles/secure-tunnel.mdx
+++ b/docs/articles/secure-tunnel.mdx
@@ -2,6 +2,18 @@
 title: Secure Tunnel
 ---
 
+:::caution{title="Linux Only"}
+
+Zuplo secure tunnels are officially supported on **Linux** environments only.
+The tunnel service is distributed as a Linux binary, and the
+[`zuplo/tunnel` Docker image](https://hub.docker.com/r/zuplo/tunnel) runs Linux
+containers. Whether you deploy the tunnel as a Docker container, on a virtual
+machine, or on bare metal, the underlying host must run Linux. This includes
+cloud container services (AWS ECS, Azure Container Instances, GCP Cloud Run,
+Kubernetes) which use Linux-based infrastructure by default.
+
+:::
+
 For customers running on bare metal, on-premises, or other non-cloud providers
 tunnels provides a way to secure your backend without mTLS or IAM.
 
@@ -19,9 +31,9 @@ private API. The benefits of a secure tunnel are:
 
 ## How does the Tunnel Work?
 
-The Zuplo tunnel can run on virtually any infrastructure. The most common way
-users install the tunnel is as a Docker container, but we can provide you a
-build in virtually any format (for example an Azure VM, etc.). The tunnel itself
+The Zuplo tunnel can run on virtually any Linux-based infrastructure. The most
+common way users install the tunnel is as a Docker container, but it can also
+run directly on a Linux virtual machine or bare-metal server. The tunnel itself
 is a lightweight service that when started makes an outbound connection to the
 Zuplo network and then through to your Zuplo Gateway.
 

--- a/docs/articles/secure-tunnel.mdx
+++ b/docs/articles/secure-tunnel.mdx
@@ -2,16 +2,6 @@
 title: Secure Tunnel
 ---
 
-:::note
-
-The tunnel service is built for **Linux** and all official deployments — whether
-via the [`zuplo/tunnel` Docker image](https://hub.docker.com/r/zuplo/tunnel), a
-virtual machine, or bare metal — run on Linux. Cloud container platforms such as
-AWS ECS, Azure Container Instances, GCP Cloud Run, and Kubernetes use
-Linux-based infrastructure by default.
-
-:::
-
 For customers running on bare metal, on-premises, or other non-cloud providers
 tunnels provides a way to secure your backend without mTLS or IAM.
 

--- a/docs/articles/secure-tunnel.mdx
+++ b/docs/articles/secure-tunnel.mdx
@@ -2,15 +2,13 @@
 title: Secure Tunnel
 ---
 
-:::caution{title="Linux Only"}
+:::note
 
-Zuplo secure tunnels are officially supported on **Linux** environments only.
-The tunnel service is distributed as a Linux binary, and the
-[`zuplo/tunnel` Docker image](https://hub.docker.com/r/zuplo/tunnel) runs Linux
-containers. Whether you deploy the tunnel as a Docker container, on a virtual
-machine, or on bare metal, the underlying host must run Linux. This includes
-cloud container services (AWS ECS, Azure Container Instances, GCP Cloud Run,
-Kubernetes) which use Linux-based infrastructure by default.
+The tunnel service is built for **Linux** and all official deployments — whether
+via the [`zuplo/tunnel` Docker image](https://hub.docker.com/r/zuplo/tunnel), a
+virtual machine, or bare metal — run on Linux. Cloud container platforms such as
+AWS ECS, Azure Container Instances, GCP Cloud Run, and Kubernetes use
+Linux-based infrastructure by default.
 
 :::
 

--- a/docs/articles/tunnel-setup.mdx
+++ b/docs/articles/tunnel-setup.mdx
@@ -4,6 +4,19 @@ title: Tunnel Setup & Use
 
 <EnterpriseFeature name="Secure tunneling" />
 
+:::caution{title="Linux Only"}
+
+The Zuplo tunnel service runs exclusively on **Linux**. The
+[`zuplo/tunnel` Docker image](https://hub.docker.com/r/zuplo/tunnel) is a Linux
+container, and any non-containerized deployment must target a Linux host. All
+major cloud container platforms (AWS ECS, Azure Container Instances, GCP Cloud
+Run, Kubernetes) run Linux containers by default, so no additional configuration
+is required when using those services. If you are deploying directly on a
+virtual machine or bare metal, ensure the host runs a supported Linux
+distribution.
+
+:::
+
 ## Setting up Tunnels
 
 A tunnel is a way to expose your _internal services_ to the Zuplo gateway

--- a/docs/articles/tunnel-setup.mdx
+++ b/docs/articles/tunnel-setup.mdx
@@ -4,16 +4,15 @@ title: Tunnel Setup & Use
 
 <EnterpriseFeature name="Secure tunneling" />
 
-:::caution{title="Linux Only"}
+:::caution{title="Platform Requirement"}
 
-The Zuplo tunnel service runs exclusively on **Linux**. The
+The Zuplo tunnel service is officially supported on **Linux** only. The
 [`zuplo/tunnel` Docker image](https://hub.docker.com/r/zuplo/tunnel) is a Linux
-container, and any non-containerized deployment must target a Linux host. All
-major cloud container platforms (AWS ECS, Azure Container Instances, GCP Cloud
-Run, Kubernetes) run Linux containers by default, so no additional configuration
-is required when using those services. If you are deploying directly on a
-virtual machine or bare metal, ensure the host runs a supported Linux
-distribution.
+container, and any non-containerized deployment must target a Linux host. Cloud
+container platforms (AWS ECS, Azure Container Instances, GCP Cloud Run,
+Kubernetes) run Linux containers by default and require no extra configuration.
+If you are deploying on a virtual machine or bare metal, ensure the host runs a
+supported Linux distribution.
 
 :::
 

--- a/docs/articles/tunnel-troubleshooting.mdx
+++ b/docs/articles/tunnel-troubleshooting.mdx
@@ -2,18 +2,13 @@
 title: Tunnel Troubleshooting
 ---
 
-:::note
-
-Before troubleshooting, confirm that your tunnel is running on a **Linux** host.
-The Zuplo tunnel service is supported on Linux only. See the
-[Secure Tunnel overview](./secure-tunnel.mdx) for platform requirements.
-
-:::
-
 Setting up a secure tunnel involves configuring several different networks to
 work together. When setting up your tunnel it's common for traffic to initially
 not reach your destination initially. This is almost always caused by
 configurations (firewalls, VPCs, IAM rules, etc.) in your internal network.
+
+As a quick sanity check, verify that the tunnel is running on a
+[supported Linux host](./secure-tunnel.mdx) before investigating further.
 
 ## Tunnel status
 

--- a/docs/articles/tunnel-troubleshooting.mdx
+++ b/docs/articles/tunnel-troubleshooting.mdx
@@ -2,6 +2,14 @@
 title: Tunnel Troubleshooting
 ---
 
+:::note
+
+Before troubleshooting, confirm that your tunnel is running on a **Linux** host.
+The Zuplo tunnel service is supported on Linux only. See the
+[Secure Tunnel overview](./secure-tunnel.mdx) for platform requirements.
+
+:::
+
 Setting up a secure tunnel involves configuring several different networks to
 work together. When setting up your tunnel it's common for traffic to initially
 not reach your destination initially. This is almost always caused by


### PR DESCRIPTION
## Summary
- Added a prominent `:::caution` admonition to **secure-tunnel.mdx** and **tunnel-setup.mdx** stating that Zuplo secure tunnels are officially supported on Linux environments only
- Added a `:::note` admonition to **tunnel-troubleshooting.mdx** reminding users to verify they are running on Linux before troubleshooting
- Updated the "How does the Tunnel Work?" section in **secure-tunnel.mdx** to say "Linux-based infrastructure" instead of "virtually any infrastructure" and removed the reference to "a build in virtually any format"

The messaging is clear but not alarming — it explains that cloud container platforms (ECS, ACI, Cloud Run, Kubernetes) use Linux by default, so most users will not need to take any special action.

## Test plan
- [ ] Verify the admonitions render correctly on the docs site
- [ ] Confirm no broken links in the tunnel docs
- [ ] Review wording for tone and accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)