### PR TITLE
Remove beta flags from GA features

### DIFF
--- a/docs/articles/accounts/roles-and-permissions.mdx
+++ b/docs/articles/accounts/roles-and-permissions.mdx
@@ -4,13 +4,6 @@ title: Role Permissions
 
 <EnterpriseFeature name="Role Based Access Control" />
 
-:::info{title="Beta"}
-
-The specific permissions of each role are currently in beta and may change
-without notice.
-
-:::
-
 Accounts in Zuplo can have multiple members with different roles. Each account
 member can be a role that defines the permissions they have in the account.
 

--- a/docs/articles/log-plugin-splunk.mdx
+++ b/docs/articles/log-plugin-splunk.mdx
@@ -1,5 +1,5 @@
 ---
-title: Splunk Plugin (Beta)
+title: Splunk Plugin
 sidebar_label: Splunk Logging
 ---
 

--- a/docs/handlers/websocket-handler.mdx
+++ b/docs/handlers/websocket-handler.mdx
@@ -16,8 +16,8 @@ like [Rate Limiting](../policies/rate-limit-inbound.mdx),
 [API Keys](../policies/api-key-inbound.mdx), etc. and is available for use on
 all environments.
 
-This handler is currently in beta and only configurable via the JSON View on a
-project's Route Designer or directly in your project's `*.oas.json` file.
+This handler is only configurable via the JSON View on a project's Route
+Designer or directly in your project's `*.oas.json` file.
 
 ## Setup in `routes.oas.json`
 

--- a/docs/programmable-api/jwt-service-plugin.mdx
+++ b/docs/programmable-api/jwt-service-plugin.mdx
@@ -14,13 +14,6 @@ can issue JWTs. Your Zuplo API will also serve the standard
 can be used by clients to discover the public keys used to verify the JWTs
 issued by your API.
 
-:::note{title="Beta Feature"}
-
-This plugin is in Beta - please use with care and provide feedback to the team
-if you encounter any issues.
-
-:::
-
 ## JWT Token
 
 This service currently issues JWTs using the EdDSA algorithm. This is the

--- a/docs/programmable-api/streaming-zone-cache.mdx
+++ b/docs/programmable-api/streaming-zone-cache.mdx
@@ -7,13 +7,6 @@ The `StreamingZoneCache` class provides a distributed caching solution optimized
 for streaming data. It allows you to cache `ReadableStream` objects across
 Zuplo's edge network.
 
-:::note{title="Beta Feature"}
-
-This API is in Beta - please use with care and provide feedback to the team if
-you encounter any issues.
-
-:::
-
 ## Constructor
 
 ```ts


### PR DESCRIPTION
## Summary

Remove beta notices and title tags from the following docs, reflecting their graduation from beta:

- `docs/programmable-api/streaming-zone-cache.mdx` — removed Beta Feature admonition
- `docs/programmable-api/jwt-service-plugin.mdx` — removed Beta Feature admonition
- `docs/handlers/websocket-handler.mdx` — removed "currently in beta" language
- `docs/articles/log-plugin-splunk.mdx` — removed "(Beta)" from title
- `docs/articles/accounts/roles-and-permissions.mdx` — removed Beta admonition

## Test plan

- [ ] Verify affected pages render correctly in the dev server
- [ ] Confirm no remaining beta references in the five updated docs
- [ ] `pnpm run check` passes
- [ ] `make lint` passes

https://claude.ai/code/session_011trxscJuYk4kvGJ8fikydC