### PR TITLE
Redirect /docs/policies/*-policy to canonical policy URLs

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -224,6 +224,11 @@
       "permanent": true
     },
     {
+      "source": "/docs/policies/:slug([^/]+)-policy{/}?",
+      "destination": "/docs/policies/:slug",
+      "permanent": true
+    },
+    {
       "source": "/docs/projects/github-source-control{/}?",
       "destination": "/docs/articles/source-control",
       "permanent": true


### PR DESCRIPTION
## Summary
- Adds a regex redirect in `vercel.json` that strips the `-policy` suffix from any `/docs/policies/*` URL
- Fixes broken incoming links like `/docs/policies/rate-limit-inbound-policy` → `/docs/policies/rate-limit-inbound`

## Test plan
- [ ] Visit `/docs/policies/rate-limit-inbound-policy` and confirm it 308-redirects to `/docs/policies/rate-limit-inbound`
- [ ] Confirm existing policy URLs (e.g. `/docs/policies/rate-limit-inbound`) still load normally
- [ ] Spot-check another policy slug with the suffix (e.g. `/docs/policies/api-key-auth-inbound-policy`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)