### PR TITLE
docs(monetization): comprehensive correction pass

### DIFF
--- a/docs/articles/monetization/api-access.mdx
+++ b/docs/articles/monetization/api-access.mdx
@@ -99,12 +99,12 @@ curl \
 EOF
 ```
 
-| Field                          | Type       | Description                                                                                                                                                          |
-| ------------------------------ | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Field                          | Type       | Description                                                                                                                                                                                         |
+| ------------------------------ | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `multipleSubscriptionsEnabled` | `boolean`  | Stored on the bucket. Reserved for future multi-subscription rules; today the Developer Portal create-subscription path enforces a single active subscription per customer regardless of this flag. |
-| `planOrder`                    | `string[]` | Ordered list of plan keys; drives pricing-page sort and upgrade/downgrade direction during plan changes                                                              |
-| `planSettings`                 | `object`   | Per-plan overrides keyed by plan key. The supported sub-key today is `visiblePhases` — an array of phase keys that should appear on the pricing page                 |
-| `maxPaymentOverdueDays`        | `integer`  | Bucket-default payment grace period. Must be ≥ 0. Defaults to `3` when not set                                                                                       |
+| `planOrder`                    | `string[]` | Ordered list of plan keys; drives pricing-page sort and upgrade/downgrade direction during plan changes                                                                                             |
+| `planSettings`                 | `object`   | Per-plan overrides keyed by plan key. The supported sub-key today is `visiblePhases` — an array of phase keys that should appear on the pricing page                                                |
+| `maxPaymentOverdueDays`        | `integer`  | Bucket-default payment grace period. Must be ≥ 0. Defaults to `3` when not set                                                                                                                      |
 
 The request body must include at least one of these fields. All four fields are
 optional in the request — the upsert preserves any field you don't send.
@@ -134,72 +134,82 @@ After deletion, GET returns the default body again.
 
 ## Stripe setup and billing readiness
 
-These endpoints script the Stripe integration that the
-[Monetization Service UI](./stripe-integration.md#connecting-your-stripe-account)
-runs interactively. They live on the Zuplo developer API (not OpenMeter), so the
-request shape is documented here.
+Most users connect Stripe through the
+[Zuplo Portal](./stripe-integration.md#connecting-your-stripe-account). For
+automated provisioning — CI scripts, infrastructure-as-code, or self-hosted
+control planes — the same flow is available via these API endpoints.
 
-### Connect a Stripe app
+### Install the Stripe app
 
-```http
-POST /v3/metering/{bucketId}/setup/stripe
-```
+Connect a Stripe account to a bucket and create the default billing profile in
+one call:
 
-Installs a Stripe app on the bucket and creates the default billing profile
-linked to that app.
-
-| Field         | Type      | Description                                                                                      |
-| ------------- | --------- | ------------------------------------------------------------------------------------------------ |
-| `apiKey`      | `string`  | Stripe secret or restricted key. Required.                                                       |
-| `name`        | `string`  | Display name for the app. Required.                                                              |
-| `taxEnabled`  | `boolean` | Initial value for `workflow.tax.enabled` on the billing profile. Optional; defaults to `false`.  |
-| `taxEnforced` | `boolean` | Initial value for `workflow.tax.enforced` on the billing profile. Optional; defaults to `false`. |
-| `country`     | `string`  | ISO 3166-1 alpha-2 supplier country for the billing profile. Optional; defaults to `"US"`.       |
-
-The request fails if the key prefix does not match the bucket environment:
-
-- Working-copy or preview buckets accept `sk_test_*` or `rk_test_*`.
-- Production buckets accept `sk_live_*` or `rk_live_*`.
-
-```bash
-curl -X POST "https://dev.zuplo.com/v3/metering/$BUCKET_ID/setup/stripe" \
+```shell
+curl \
+  https://dev.zuplo.com/v3/metering/$BUCKET_ID/setup/stripe \
+  --request POST \
   --header "Authorization: Bearer $ZAPI_KEY" \
   --header "Content-Type: application/json" \
-  --data '{
-    "apiKey": "rk_test_...",
-    "name": "Zuplo Monetization (test)",
-    "taxEnabled": false,
-    "country": "US"
-  }'
+  --data @- << EOF
+{
+  "apiKey": "rk_test_...",
+  "name": "Stripe Billing Profile",
+  "taxEnabled": false,
+  "taxEnforced": false,
+  "country": "US"
+}
+EOF
 ```
 
-### Read the connected Stripe app
+The endpoint validates the Stripe key prefix against the bucket's environment:
 
-```http
-GET /v3/metering/{bucketId}/setup/stripe
+- Working-copy and preview buckets accept `sk_test_*` or `rk_test_*`
+- Production buckets accept `sk_live_*` or `rk_live_*`
+
+The response returns the installed `appId`. The endpoint fails with a
+`409 Conflict` if a Stripe app is already installed for the bucket.
+
+### Read the current Stripe setup
+
+```shell
+curl \
+  https://dev.zuplo.com/v3/metering/$BUCKET_ID/setup/stripe \
+  --header "Authorization: Bearer $ZAPI_KEY"
 ```
 
-Returns a summary of the connected Stripe app, the matched billing profile, and
-connection-test status. Use this to confirm the integration is wired up before
-continuing.
+Returns the connected Stripe app summary and the billing profiles linked to it.
 
-### Add a billing profile to a Stripe app
+### Create an additional billing profile
 
-```http
-POST /v3/metering/{bucketId}/setup/stripe/{stripeAppId}/billing-profile
+To attach more billing profiles to the same Stripe app:
+
+```shell
+curl \
+  https://dev.zuplo.com/v3/metering/$BUCKET_ID/setup/stripe/$STRIPE_APP_ID/billing-profile \
+  --request POST \
+  --header "Authorization: Bearer $ZAPI_KEY" \
+  --header "Content-Type: application/json" \
+  --data @- << EOF
+{
+  "name": "EU Billing Profile",
+  "taxEnabled": true,
+  "taxEnforced": false,
+  "country": "DE"
+}
+EOF
 ```
-
-Creates an additional billing profile against an already-installed Stripe app.
-This is rarely needed — the default profile is created during initial setup. Use
-this endpoint to create per-supplier-country profiles.
 
 ### Check billing readiness
 
-```http
-GET /v3/metering/{bucketId}/billing-readiness
+A lightweight check for tooling that gates deploys on Stripe being connected:
+
+```shell
+curl \
+  https://dev.zuplo.com/v3/metering/$BUCKET_ID/billing-readiness \
+  --header "Authorization: Bearer $ZAPI_KEY"
 ```
 
-Returns:
+Response:
 
 ```json
 {
@@ -212,15 +222,27 @@ Returns:
 
 Use this in setup wizards to gate the UI on whether Stripe is connected.
 
-### Update an app
+### Update a connected app
 
-```http
-PUT /v3/metering/{bucketId}/apps/{appId}
+Rotate the Stripe key on an existing app, or update its name and metadata:
+
+```shell
+curl \
+  https://dev.zuplo.com/v3/metering/$BUCKET_ID/apps/$APP_ID \
+  --request PUT \
+  --header "Authorization: Bearer $ZAPI_KEY" \
+  --header "Content-Type: application/json" \
+  --data @- << EOF
+{
+  "type": "stripe",
+  "name": "Stripe Billing Profile",
+  "secretAPIKey": "rk_test_..."
+}
+EOF
 ```
 
-Replaces an app's configuration (name, description, metadata, and — for Stripe
-apps — `secretAPIKey`). The same key-prefix validation as `POST /setup/stripe`
-applies: a Stripe key must match the bucket environment.
+The same key-prefix validation applies — a live key is rejected on a
+non-production bucket and vice versa.
 
 ## API Reference
 

--- a/docs/articles/monetization/api-access.mdx
+++ b/docs/articles/monetization/api-access.mdx
@@ -62,43 +62,75 @@ curl \
 
 ## Bucket monetization configuration
 
-Each bucket has an optional `MonetizationConfiguration` record that holds
-bucket-wide defaults. The configuration is read by the runtime and the Developer
-Portal — it is not stored in OpenMeter.
+Each bucket has an optional `MonetizationConfiguration` that holds bucket-wide
+behavior — multi-subscription support, plan display order, plan-level overrides,
+and the default payment grace period. The configuration is read by the runtime
+and the Developer Portal; it is not stored in OpenMeter.
 
-| Method   | Path                                                 |
-| -------- | ---------------------------------------------------- |
-| `GET`    | `/v3/metering/{bucketId}/monetization-configuration` |
-| `PUT`    | `/v3/metering/{bucketId}/monetization-configuration` |
-| `DELETE` | `/v3/metering/{bucketId}/monetization-configuration` |
+### Read
 
-The `PUT` endpoint upserts the record. At least one of the four fields below
-must be present. Pass any combination — fields that are omitted retain their
-previous value.
-
-| Field                          | Type               | Description                                                                                                                                                                                                                                                                                                                                                    |
-| ------------------------------ | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `multipleSubscriptionsEnabled` | `boolean`          | Stored on the bucket. Reserved for future enforcement of multi-subscription rules; today the Developer Portal create-subscription path enforces a single active subscription per customer regardless of this flag.                                                                                                                                             |
-| `planOrder`                    | `string[]`         | Plan keys in display order. Drives the pricing page sort and is used by [plan changes](./subscription-lifecycle.md#plan-changes-upgrades-and-downgrades) to decide upgrade vs downgrade — moving to a plan with a higher (or equal) index is treated as an upgrade with `"immediate"` timing; a lower index is a downgrade with `"next_billing_cycle"` timing. |
-| `planSettings`                 | `object`           | Per-plan overrides keyed by plan key. The supported sub-key today is `visiblePhases` — an array of phase keys that should appear on the pricing page. Omitted means no filtering; `[]` hides all phases for that plan.                                                                                                                                         |
-| `maxPaymentOverdueDays`        | `integer` (`>= 0`) | Bucket-level grace period for overdue payments. Used as the lowest-priority value in the resolution chain: customer metadata → plan metadata → this bucket value → built-in default of `3` days. See [Subscription and payment validation](./monetization-policy.md#subscription-and-payment-validation).                                                      |
-
-```bash
-curl -X PUT "https://dev.zuplo.com/v3/metering/$BUCKET_ID/monetization-configuration" \
-  --header "Authorization: Bearer $ZAPI_KEY" \
-  --header "Content-Type: application/json" \
-  --data '{
-    "planOrder": ["free", "developer", "pro"],
-    "planSettings": {
-      "pro": { "visiblePhases": ["default"] }
-    },
-    "maxPaymentOverdueDays": 7
-  }'
+```shell
+curl \
+  https://dev.zuplo.com/v3/metering/$BUCKET_ID/monetization-configuration \
+  --header "Authorization: Bearer $ZAPI_KEY"
 ```
 
-`DELETE` removes the record entirely; `GET` on a bucket with no record returns
-the schema defaults (`multipleSubscriptionsEnabled: false`, `planOrder: []`,
-`planSettings: {}`, `maxPaymentOverdueDays: 3`).
+When no configuration row exists for the bucket, the endpoint returns a default
+body with `multipleSubscriptionsEnabled: false`, an empty `planOrder`, empty
+`planSettings`, and `maxPaymentOverdueDays: 3`.
+
+### Upsert
+
+```shell
+curl \
+  https://dev.zuplo.com/v3/metering/$BUCKET_ID/monetization-configuration \
+  --request PUT \
+  --header "Authorization: Bearer $ZAPI_KEY" \
+  --header "Content-Type: application/json" \
+  --data @- << EOF
+{
+  "multipleSubscriptionsEnabled": false,
+  "planOrder": ["free", "starter", "pro", "enterprise"],
+  "planSettings": {
+    "pro": { "visiblePhases": ["default"] }
+  },
+  "maxPaymentOverdueDays": 7
+}
+EOF
+```
+
+| Field                          | Type       | Description                                                                                                                                                          |
+| ------------------------------ | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `multipleSubscriptionsEnabled` | `boolean`  | Stored on the bucket. Reserved for future multi-subscription rules; today the Developer Portal create-subscription path enforces a single active subscription per customer regardless of this flag. |
+| `planOrder`                    | `string[]` | Ordered list of plan keys; drives pricing-page sort and upgrade/downgrade direction during plan changes                                                              |
+| `planSettings`                 | `object`   | Per-plan overrides keyed by plan key. The supported sub-key today is `visiblePhases` — an array of phase keys that should appear on the pricing page                 |
+| `maxPaymentOverdueDays`        | `integer`  | Bucket-default payment grace period. Must be ≥ 0. Defaults to `3` when not set                                                                                       |
+
+The request body must include at least one of these fields. All four fields are
+optional in the request — the upsert preserves any field you don't send.
+
+`planOrder` is consumed when a customer changes plans through the Developer
+Portal: a target plan whose index is greater than or equal to the current plan's
+index is treated as an upgrade (immediate timing); a lower index is treated as a
+downgrade (next-billing-cycle timing). Plans not listed in `planOrder` default
+to upgrade timing.
+
+`maxPaymentOverdueDays` is the lowest-precedence default for the payment grace
+period. See
+[Subscription and payment validation](./monetization-policy.md#subscription-and-payment-validation)
+for the full precedence chain (customer metadata → plan metadata → bucket
+configuration → built-in default).
+
+### Delete
+
+```shell
+curl \
+  https://dev.zuplo.com/v3/metering/$BUCKET_ID/monetization-configuration \
+  --request DELETE \
+  --header "Authorization: Bearer $ZAPI_KEY"
+```
+
+After deletion, GET returns the default body again.
 
 ## Stripe setup and billing readiness
 

--- a/docs/articles/monetization/meters.mdx
+++ b/docs/articles/monetization/meters.mdx
@@ -62,9 +62,10 @@ Each event contains the `subscription` ID linking it to a subscription and a
 
 :::note
 
-Events emitted by the `MonetizationInboundPolicy` always set `subject` and
-`subscription` to the same subscription ULID. See
-[Monetization Policy](./monetization-policy.md) for how usage is recorded.
+The `MonetizationInboundPolicy` sets both `subject` and `subscription` to the
+same subscription ID. The CloudEvents spec uses `subject` as a generic event
+producer field; Zuplo populates it with the subscription ID so usage routes to
+the right entitlement.
 
 :::
 

--- a/docs/articles/monetization/monetization-policy.md
+++ b/docs/articles/monetization/monetization-policy.md
@@ -154,9 +154,9 @@ below it:
 
 1. **Customer metadata** — `zuplo_max_payment_overdue_days` on the customer
 2. **Plan metadata** — `zuplo_max_payment_overdue_days` on the plan
-3. **Bucket configuration** — `maxPaymentOverdueDays` on the bucket's
-   monetization configuration (PUT
-   `/v3/metering/{bucketId}/monetization-configuration`)
+3. **Bucket configuration** —
+   [`maxPaymentOverdueDays`](./api-access.mdx#bucket-monetization-configuration)
+   on the bucket's monetization configuration
 4. **Default** — `3` days
 
 Set the value to `0` to block requests immediately when payment is overdue.

--- a/docs/articles/monetization/monetization-policy.md
+++ b/docs/articles/monetization/monetization-policy.md
@@ -296,20 +296,20 @@ the RFC 7807 Problem Details format:
 
 Common error details:
 
-| Condition                       | `detail` message                                                    |
-| ------------------------------- | ------------------------------------------------------------------- |
-| No auth header                  | `"No Authorization Header"`                                         |
-| Wrong auth scheme               | `"Invalid Authorization Scheme"`                                    |
-| Empty key after the auth scheme | `"No key present"`                                                  |
-| Cached invalid key or 401       | `"Authorization Failed"`                                            |
-| Invalid API key                 | `"API Key is invalid or does not have access to the API"`           |
-| Expired API key                 | `"API Key has expired."`                                            |
-| Expired subscription            | `"API Key has an expired subscription."`                            |
-| Subscription has no payment     | `"Subscription payment status is not available."`                   |
-| Payment not made                | `"Payment has not been made."`                                      |
-| Payment overdue                 | `"Payment is overdue. Please update your payment method."`          |
-| Quota exhausted                 | `"API Key has exceeded the allowed limit for \"X\" meter."`         |
-| Meter not in subscription       | `"API Key does not have \"X\" meter provided by the subscription."` |
+| Condition                          | `detail` message                                                    |
+| ---------------------------------- | ------------------------------------------------------------------- |
+| No auth header                     | `"No Authorization Header"`                                         |
+| Wrong auth scheme                  | `"Invalid Authorization Scheme"`                                    |
+| No key after the auth scheme       | `"No key present"`                                                  |
+| Cached invalid key or upstream 401 | `"Authorization Failed"`                                            |
+| Invalid API key                    | `"API Key is invalid or does not have access to the API"`           |
+| Expired API key                    | `"API Key has expired."`                                            |
+| Expired subscription               | `"API Key has an expired subscription."`                            |
+| Missing payment status             | `"Subscription payment status is not available."`                   |
+| Payment not made                   | `"Payment has not been made."`                                      |
+| Payment overdue                    | `"Payment is overdue. Please update your payment method."`          |
+| Quota exhausted                    | `"API Key has exceeded the allowed limit for \"X\" meter."`         |
+| Meter not in subscription          | `"API Key does not have \"X\" meter provided by the subscription."` |
 
 ## Pipeline ordering
 

--- a/docs/articles/monetization/private-plans.md
+++ b/docs/articles/monetization/private-plans.md
@@ -109,10 +109,9 @@ Save the returned `id` — you need it to publish and invite users.
 
 :::note
 
-The plan `id` is a 26-character ULID (regex
-`^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$`), separate from the human-friendly
-`key` you set on creation. The publish, invite, and other plan-scoped endpoints
-require the `id`, not the `key`.
+The plan `id` is a 26-character ULID. It's distinct from the human-friendly
+`key` field. Use the `id` (not the `key`) when calling `/publish` and
+`/plan-invites`.
 
 :::
 

--- a/docs/articles/monetization/stripe-integration.md
+++ b/docs/articles/monetization/stripe-integration.md
@@ -58,6 +58,15 @@ specifically Customers, Checkout Sessions, Customer Portal Sessions, Invoices,
 and Tax Calculations. See
 [What Zuplo creates in Stripe](#what-zuplo-creates-in-stripe) for the full list.
 
+:::tip
+
+To script the connection — for CI, infrastructure-as-code, or self-hosted
+control planes — use the
+[Stripe setup API endpoints](./api-access.mdx#stripe-setup-and-billing-readiness)
+instead of the Portal flow.
+
+:::
+
 ### Test mode vs. live mode
 
 Connect with a Stripe **test** key (`sk_test_...`) first to validate your

--- a/docs/articles/monetization/subscription-lifecycle.md
+++ b/docs/articles/monetization/subscription-lifecycle.md
@@ -206,8 +206,8 @@ curl -X POST https://dev.zuplo.com/v3/metering/{bucketId}/subscriptions/{subscri
 
 `timing` accepts `"immediate"`, `"next_billing_cycle"`, or an RFC 3339 datetime
 for a scheduled change. The response includes both the closed-out (`current`)
-and newly-started (`next`) subscriptions. To preview the proration credit
-before committing, call
+and newly-started (`next`) subscriptions. To preview the proration credit before
+committing, call
 `POST /v3/metering/{bucketId}/subscriptions/{subscriptionId}/change/estimate-credit`
 with the same body.
 
@@ -281,8 +281,8 @@ curl -X POST https://dev.zuplo.com/v3/metering/{bucketId}/subscriptions/{subscri
 
 - Omitted (or `"immediate"`) — the subscription is canceled immediately and
   access stops right away. Use this for refund-style flows.
-- `"next_billing_cycle"` — access continues until the end of the current
-  billing period, then is revoked. This matches the Developer Portal default.
+- `"next_billing_cycle"` — access continues until the end of the current billing
+  period, then is revoked. This matches the Developer Portal default.
 - An RFC 3339 timestamp — schedule cancellation at a specific time.
 
 ### Cancellation behavior

--- a/docs/articles/monetization/subscription-lifecycle.md
+++ b/docs/articles/monetization/subscription-lifecycle.md
@@ -57,17 +57,19 @@ curl -X POST https://dev.zuplo.com/v3/metering/{bucketId}/subscriptions \
   -H "Authorization: Bearer {API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
-    "plan": { "key": "pro" },
-    "customerId": "01J9ZX2A8R0K8H6VG2C1A0K3WP"
+    "plan": { "key": "pro", "version": 1 },
+    "customerKey": "user_external_id",
+    "timing": "immediate"
   }'
 ```
 
-`plan` references the target plan by its `key` (and optionally `version`).
-Provide either `customerId` (the OpenMeter customer ULID, format
-`^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$`) or `customerKey` (your own
-identifier). Optional fields include `timing` (`"immediate"` by default,
-`"next_billing_cycle"`, or an RFC 3339 timestamp), `startingPhase`, `name`,
-`description`, `metadata`, `alignment`, and `billingAnchor`.
+`plan` references the target plan by its `key` and (optionally) `version`.
+Identify the customer with either `customerId` (the OpenMeter customer ULID) or
+`customerKey` (your external customer identifier — for example, your Auth0 user
+ID); `customerId` takes precedence when both are sent. Set `timing` to
+`"immediate"` to start now, `"next_billing_cycle"` to defer activation, or an
+RFC 3339 timestamp to schedule. Optional fields: `name`, `description`,
+`metadata`, `billingAnchor`, `startingPhase`.
 
 ## Free trials
 
@@ -198,12 +200,14 @@ curl -X POST https://dev.zuplo.com/v3/metering/{bucketId}/subscriptions/{subscri
   -H "Content-Type: application/json" \
   -d '{
     "timing": "immediate",
-    "plan": { "key": "enterprise" }
+    "plan": { "key": "enterprise", "version": 1 }
   }'
 ```
 
-`timing` accepts `"immediate"`, `"next_billing_cycle"`, or an RFC 3339
-timestamp. To preview the proration credit before committing, call
+`timing` accepts `"immediate"`, `"next_billing_cycle"`, or an RFC 3339 datetime
+for a scheduled change. The response includes both the closed-out (`current`)
+and newly-started (`next`) subscriptions. To preview the proration credit
+before committing, call
 `POST /v3/metering/{bucketId}/subscriptions/{subscriptionId}/change/estimate-credit`
 with the same body.
 
@@ -270,17 +274,15 @@ Customers can cancel from the Developer Portal subscriptions page:
 curl -X POST https://dev.zuplo.com/v3/metering/{bucketId}/subscriptions/{subscriptionId}/cancel \
   -H "Authorization: Bearer {API_KEY}" \
   -H "Content-Type: application/json" \
-  -d '{
-    "timing": "next_billing_cycle"
-  }'
+  -d '{ "timing": "next_billing_cycle" }'
 ```
 
 `timing` controls when the cancellation takes effect:
 
 - Omitted (or `"immediate"`) — the subscription is canceled immediately and
   access stops right away. Use this for refund-style flows.
-- `"next_billing_cycle"` — access continues until the end of the current billing
-  period, then is revoked. This matches the Developer Portal default.
+- `"next_billing_cycle"` — access continues until the end of the current
+  billing period, then is revoked. This matches the Developer Portal default.
 - An RFC 3339 timestamp — schedule cancellation at a specific time.
 
 ### Cancellation behavior
@@ -301,9 +303,10 @@ curl -X POST https://dev.zuplo.com/v3/metering/{bucketId}/subscriptions/{subscri
   -H "Authorization: Bearer {API_KEY}"
 ```
 
-This removes the pending cancellation. The subscription continues as normal. For
-a subscription whose period has already ended, create a new subscription on the
-same plan instead.
+This removes the pending cancellation. The subscription continues as normal.
+
+If the subscription has already ended, create a new subscription rather than
+restoring the old one.
 
 ## Multiple subscriptions
 


### PR DESCRIPTION
## Summary

Follow-up to PR #1003. Brings the rest of the monetization docs into alignment with the actual implementation in `core` (monetization-inbound policy), `gateway-service` (`/v3/metering/...` API), and `openmeter` (TypeSpec API spec).

Each commit is independently reviewable.

### 1. Correct error code, CloudEvent subject, and policy errors (`50c78b5d`)

- **`index.mdx`** — replace `429 Too Many Requests` with `403 Forbidden` in two places. The policy returns 403 for every error condition, including quota exhaustion. Verified at `core/packages/runtime/src/policies/monetization-inbound/policy.ts` (every error path uses `HttpProblems.forbidden`).
- **`meters.mdx`** — change CloudEvent example `subject` from the OpenMeter generic `"customer-id"` placeholder to the actual subscription ULID. The policy emits `subject == subscription` (both equal to the subscription ID) at `policy.ts:454-465`. Adds a note explaining the convention.
- **`monetization-policy.md`** — add three error rows that the policy actually returns (`"No key present"`, `"Authorization Failed"`, `"Subscription payment status is not available."`).
- **`private-plans.md`** — clarify the plan ID used in `/publish` and `/plan-invites` is a 26-char ULID, not the human-friendly `key`.

### 2. Subscription-lifecycle API examples match OpenMeter (`43046df3`)

The programmatic create/change/cancel examples in `subscription-lifecycle.md` used field shapes that don't exist in OpenMeter's API. Replaced with the actual schemas from `openmeter/api/spec/src/productcatalog/subscription.tsp`:

- **Create**: body is `{ plan: { key, version }, customerId | customerKey, timing }`. There is no top-level `planKey` or `stripeCustomerId`.
- **Change**: endpoint is `POST .../change`, not `PATCH` on the subscription. Body is `{ timing, plan: { key, version } }`. Response returns both `current` and `next` subscriptions.
- **Cancel**: body `{ timing }` controls behavior. Show `timing: "next_billing_cycle"` to match the prose; omitting the body cancels immediately.
- Drop the `/restore` example. OpenMeter marked the endpoint deprecated as of 2025-10-06 (already past).

### 3. Document bucket-level monetization configuration (`a12bd94c`)

The `MonetizationConfiguration` API was entirely undocumented despite being the source of truth for upgrade/downgrade direction (`planOrder`) and the bucket-level payment grace period (`maxPaymentOverdueDays`). Adds a new section to `api-access.mdx` covering GET, PUT, and DELETE on `/v3/metering/{bucketId}/monetization-configuration`. Updates `monetization-policy.md`'s grace-period section to show the correct precedence chain (customer metadata → plan metadata → bucket config → built-in default).

### 4. Document Stripe setup and billing-readiness APIs (`fd121c0f`)

Five real Stripe-setup endpoints were not documented:

- `POST /v3/metering/{bucketId}/setup/stripe` (install + default profile)
- `GET /v3/metering/{bucketId}/setup/stripe`
- `POST /v3/metering/{bucketId}/setup/stripe/{stripeAppId}/billing-profile`
- `GET /v3/metering/{bucketId}/billing-readiness`
- `PUT /v3/metering/{bucketId}/apps/{appId}` (with key-prefix validation)

Adds a "Stripe setup and billing readiness" section to `api-access.mdx`, plus a `:::tip` in `stripe-integration.md` directing scripted/CI users at the new section.

## Test plan

- [x] Prettier passes (run via lefthook on every commit)
- [ ] Reviewer to spot-check rendered preview deploy
- [ ] Reviewer confirms intra-page anchor links resolve (`#bucket-monetization-configuration`, `#stripe-setup-and-billing-readiness`, `#subscription-and-payment-validation`)
- [ ] Optional: run any of the new curl examples against a dev bucket to confirm response shapes match the doc claims