### PR TITLE
docs(monetization): align docs with verified implementation

### DIFF
--- a/docs/articles/monetization/api-access.mdx
+++ b/docs/articles/monetization/api-access.mdx
@@ -60,6 +60,136 @@ curl \
   --header "Authorization: Bearer $ZAPI_KEY"
 ```
 
+## Bucket monetization configuration
+
+Each bucket has an optional `MonetizationConfiguration` record that holds
+bucket-wide defaults. The configuration is read by the runtime and the Developer
+Portal — it is not stored in OpenMeter.
+
+| Method   | Path                                                 |
+| -------- | ---------------------------------------------------- |
+| `GET`    | `/v3/metering/{bucketId}/monetization-configuration` |
+| `PUT`    | `/v3/metering/{bucketId}/monetization-configuration` |
+| `DELETE` | `/v3/metering/{bucketId}/monetization-configuration` |
+
+The `PUT` endpoint upserts the record. At least one of the four fields below
+must be present. Pass any combination — fields that are omitted retain their
+previous value.
+
+| Field                          | Type               | Description                                                                                                                                                                                                                                                                                                                                                    |
+| ------------------------------ | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `multipleSubscriptionsEnabled` | `boolean`          | Stored on the bucket. Reserved for future enforcement of multi-subscription rules; today the Developer Portal create-subscription path enforces a single active subscription per customer regardless of this flag.                                                                                                                                             |
+| `planOrder`                    | `string[]`         | Plan keys in display order. Drives the pricing page sort and is used by [plan changes](./subscription-lifecycle.md#plan-changes-upgrades-and-downgrades) to decide upgrade vs downgrade — moving to a plan with a higher (or equal) index is treated as an upgrade with `"immediate"` timing; a lower index is a downgrade with `"next_billing_cycle"` timing. |
+| `planSettings`                 | `object`           | Per-plan overrides keyed by plan key. The supported sub-key today is `visiblePhases` — an array of phase keys that should appear on the pricing page. Omitted means no filtering; `[]` hides all phases for that plan.                                                                                                                                         |
+| `maxPaymentOverdueDays`        | `integer` (`>= 0`) | Bucket-level grace period for overdue payments. Used as the lowest-priority value in the resolution chain: customer metadata → plan metadata → this bucket value → built-in default of `3` days. See [Subscription and payment validation](./monetization-policy.md#subscription-and-payment-validation).                                                      |
+
+```bash
+curl -X PUT "https://dev.zuplo.com/v3/metering/$BUCKET_ID/monetization-configuration" \
+  --header "Authorization: Bearer $ZAPI_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "planOrder": ["free", "developer", "pro"],
+    "planSettings": {
+      "pro": { "visiblePhases": ["default"] }
+    },
+    "maxPaymentOverdueDays": 7
+  }'
+```
+
+`DELETE` removes the record entirely; `GET` on a bucket with no record returns
+the schema defaults (`multipleSubscriptionsEnabled: false`, `planOrder: []`,
+`planSettings: {}`, `maxPaymentOverdueDays: 3`).
+
+## Stripe setup and billing readiness
+
+These endpoints script the Stripe integration that the
+[Monetization Service UI](./stripe-integration.md#connecting-your-stripe-account)
+runs interactively. They live on the Zuplo developer API (not OpenMeter), so the
+request shape is documented here.
+
+### Connect a Stripe app
+
+```http
+POST /v3/metering/{bucketId}/setup/stripe
+```
+
+Installs a Stripe app on the bucket and creates the default billing profile
+linked to that app.
+
+| Field         | Type      | Description                                                                                      |
+| ------------- | --------- | ------------------------------------------------------------------------------------------------ |
+| `apiKey`      | `string`  | Stripe secret or restricted key. Required.                                                       |
+| `name`        | `string`  | Display name for the app. Required.                                                              |
+| `taxEnabled`  | `boolean` | Initial value for `workflow.tax.enabled` on the billing profile. Optional; defaults to `false`.  |
+| `taxEnforced` | `boolean` | Initial value for `workflow.tax.enforced` on the billing profile. Optional; defaults to `false`. |
+| `country`     | `string`  | ISO 3166-1 alpha-2 supplier country for the billing profile. Optional; defaults to `"US"`.       |
+
+The request fails if the key prefix does not match the bucket environment:
+
+- Working-copy or preview buckets accept `sk_test_*` or `rk_test_*`.
+- Production buckets accept `sk_live_*` or `rk_live_*`.
+
+```bash
+curl -X POST "https://dev.zuplo.com/v3/metering/$BUCKET_ID/setup/stripe" \
+  --header "Authorization: Bearer $ZAPI_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "apiKey": "rk_test_...",
+    "name": "Zuplo Monetization (test)",
+    "taxEnabled": false,
+    "country": "US"
+  }'
+```
+
+### Read the connected Stripe app
+
+```http
+GET /v3/metering/{bucketId}/setup/stripe
+```
+
+Returns a summary of the connected Stripe app, the matched billing profile, and
+connection-test status. Use this to confirm the integration is wired up before
+continuing.
+
+### Add a billing profile to a Stripe app
+
+```http
+POST /v3/metering/{bucketId}/setup/stripe/{stripeAppId}/billing-profile
+```
+
+Creates an additional billing profile against an already-installed Stripe app.
+This is rarely needed — the default profile is created during initial setup. Use
+this endpoint to create per-supplier-country profiles.
+
+### Check billing readiness
+
+```http
+GET /v3/metering/{bucketId}/billing-readiness
+```
+
+Returns:
+
+```json
+{
+  "hasStripeApp": true,
+  "stripeAppId": "app_01H...",
+  "hasDefaultBillingProfile": true,
+  "defaultBillingProfileId": "bp_01H..."
+}
+```
+
+Use this in setup wizards to gate the UI on whether Stripe is connected.
+
+### Update an app
+
+```http
+PUT /v3/metering/{bucketId}/apps/{appId}
+```
+
+Replaces an app's configuration (name, description, metadata, and — for Stripe
+apps — `secretAPIKey`). The same key-prefix validation as `POST /setup/stripe`
+applies: a Stripe key must match the bucket environment.
+
 ## API Reference
 
 For complete API operations, see the API Reference documentation:

--- a/docs/articles/monetization/index.mdx
+++ b/docs/articles/monetization/index.mdx
@@ -28,8 +28,8 @@ and invoices come out wrong.
 
 Zuplo eliminates this by making the gateway the single source of truth. Every
 request that hits your API is metered, enforced, and billed through one system.
-When a customer's quota runs out, they get a `429` immediately — not five
-minutes later when a batch job catches up.
+When a customer's quota runs out, they get a `403 Forbidden` immediately — not
+five minutes later when a batch job catches up.
 
 ## Core concepts
 
@@ -73,7 +73,7 @@ with automatic conversion to paid, and multiple subscriptions per customer.
 - **Built-in metering** — Count requests, tokens, bytes, or any custom
   dimension. No external metering service required.
 - **Real-time quota enforcement** — Customers hitting their limit get a
-  `429 Too Many Requests` response instantly, not after a batch sync.
+  `403 Forbidden` response instantly, not after a batch sync.
 - **Stripe billing integration** — Subscriptions, invoicing, and payment
   collection handled by Stripe. Zuplo keeps access state synchronized
   automatically.
@@ -93,21 +93,21 @@ pricing, wire up Stripe, and configure your gateway to enforce quotas.
 
 ## Documentation map
 
-| Document                                                               | What it covers                                           |
-| ---------------------------------------------------------------------- | -------------------------------------------------------- |
-| [Quickstart](./monetization/quickstart.md)                             | End-to-end setup in 30 minutes                           |
-| [Meters](./monetization/meters.mdx)                                    | How meters track usage dimensions                        |
-| [Features](./monetization/features.mdx)                                | Connecting meters to your product catalog                |
-| [Plans](./monetization/plans.mdx)                                      | Plan structure, phases, lifecycle, and publishing        |
-| [Rate Cards](./monetization/rate-cards.mdx)                            | Pricing and entitlements within plans                    |
-| [Pricing Models](./monetization/pricing-models.mdx)                    | Flat, per-unit, tiered, volume, and package pricing      |
-| [Billing Models Guide](./monetization/billing-models.md)               | Choosing the right pricing strategy for your business    |
-| [Stripe Integration](./monetization/stripe-integration.md)             | Connecting Stripe and managing payments                  |
-| [Developer Portal Setup](./monetization/developer-portal.md)           | Configuring the self-serve portal for your customers     |
-| [Monetization Policy Reference](./monetization/monetization-policy.md) | Configuring the `MonetizationInboundPolicy` per-route    |
-| [API Access](./monetization/api-access.mdx)                            | Authentication, buckets, and API reference links         |
-| [Subscription Lifecycle](./monetization/subscription-lifecycle.md)     | Managing trials, upgrades, downgrades, and cancellations |
-| [Private Plans](./monetization/private-plans.md)                       | Invite-only plans for specific users                     |
-| [Tax Collection](./monetization/tax-collection.md)                     | Enabling VAT, sales tax, or GST via Stripe Tax           |
-| [Plan Examples](./monetization/plan-examples.mdx)                      | Real-world plan configurations                           |
-| [Troubleshooting](./monetization/troubleshooting.md)                   | Common issues, debugging, and FAQ                        |
+| Document                                                               | What it covers                                                                        |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| [Quickstart](./monetization/quickstart.md)                             | End-to-end setup in 30 minutes                                                        |
+| [Meters](./monetization/meters.mdx)                                    | How meters track usage dimensions                                                     |
+| [Features](./monetization/features.mdx)                                | Connecting meters to your product catalog                                             |
+| [Plans](./monetization/plans.mdx)                                      | Plan structure, phases, lifecycle, and publishing                                     |
+| [Rate Cards](./monetization/rate-cards.mdx)                            | Pricing and entitlements within plans                                                 |
+| [Pricing Models](./monetization/pricing-models.mdx)                    | Flat, per-unit, tiered, volume, and package pricing                                   |
+| [Billing Models Guide](./monetization/billing-models.md)               | Choosing the right pricing strategy for your business                                 |
+| [Stripe Integration](./monetization/stripe-integration.md)             | Connecting Stripe and managing payments                                               |
+| [Developer Portal Setup](./monetization/developer-portal.md)           | Configuring the self-serve portal for your customers                                  |
+| [Monetization Policy Reference](./monetization/monetization-policy.md) | Configuring the `MonetizationInboundPolicy` per-route                                 |
+| [API Access](./monetization/api-access.mdx)                            | Authentication, buckets, bucket configuration, Stripe setup APIs, and reference links |
+| [Subscription Lifecycle](./monetization/subscription-lifecycle.md)     | Managing trials, upgrades, downgrades, and cancellations                              |
+| [Private Plans](./monetization/private-plans.md)                       | Invite-only plans for specific users                                                  |
+| [Tax Collection](./monetization/tax-collection.md)                     | Enabling VAT, sales tax, or GST via Stripe Tax                                        |
+| [Plan Examples](./monetization/plan-examples.mdx)                      | Real-world plan configurations                                                        |
+| [Troubleshooting](./monetization/troubleshooting.md)                   | Common issues, debugging, and FAQ                                                     |

--- a/docs/articles/monetization/meters.mdx
+++ b/docs/articles/monetization/meters.mdx
@@ -52,13 +52,21 @@ Each event contains the `subscription` ID linking it to a subscription and a
   "specversion": "1.0",
   "type": "api_requests",
   "source": "monetization-policy",
-  "subject": "customer-id",
+  "subject": "01KNVXHQG356VA7T7W0V9N21GH",
   "subscription": "01KNVXHQG356VA7T7W0V9N21GH",
   "data": {
     "total": 1
   }
 }
 ```
+
+:::note
+
+Events emitted by the `MonetizationInboundPolicy` always set `subject` and
+`subscription` to the same subscription ULID. See
+[Monetization Policy](./monetization-policy.md) for how usage is recorded.
+
+:::
 
 ### Token Usage
 
@@ -83,7 +91,7 @@ configured to report 50 tokens per request:
   "specversion": "1.0",
   "type": "tokens",
   "source": "monetization-policy",
-  "subject": "customer-id",
+  "subject": "01KNVXHQG356VA7T7W0V9N21GH",
   "subscription": "01KNVXHQG356VA7T7W0V9N21GH",
   "data": {
     "total": 50
@@ -113,7 +121,7 @@ Each event reports the number of bytes transferred:
   "specversion": "1.0",
   "type": "data_transfer",
   "source": "monetization-policy",
-  "subject": "customer-id",
+  "subject": "01KNVXHQG356VA7T7W0V9N21GH",
   "subscription": "01KNVXHQG356VA7T7W0V9N21GH",
   "data": {
     "total": 4096

--- a/docs/articles/monetization/monetization-policy.md
+++ b/docs/articles/monetization/monetization-policy.md
@@ -19,24 +19,25 @@ and allows or blocks access.
 
 ## Basic configuration
 
-Add the policy in the Zuplo Portal under **Code → policies.json → Create Policy
-→ Monetization**. The policy editor shows the handler block:
+Add the policy to your `policies.json`:
 
 ```json
 {
-  "export": "MonetizationInboundPolicy",
-  "module": "$import(@zuplo/runtime)",
-  "options": {
-    "meters": {
-      "api_requests": 1
+  "name": "monetization-inbound",
+  "policyType": "monetization-inbound",
+  "handler": {
+    "export": "MonetizationInboundPolicy",
+    "module": "$import(@zuplo/runtime)",
+    "options": {
+      "meters": {
+        "api_requests": 1
+      }
     }
   }
 }
 ```
 
-The Portal saves this as a named entry inside `policies.json`, with the `name`
-and `policyType` fields filled in for you. Reference the policy from your
-route's inbound pipeline:
+Then reference it in your route's inbound policy pipeline:
 
 ```json
 {
@@ -162,43 +163,45 @@ Set the value to `0` to block requests immediately when payment is overdue.
 
 ## Multiple policies for different routes
 
-Different routes can have different metering configurations. Create one policy
-per configuration in the Portal — each one is a separate handler block:
-
-`monetization-standard`:
+Different routes can have different metering configurations. Define multiple
+policy instances in `policies.json`:
 
 ```json
-{
-  "export": "MonetizationInboundPolicy",
-  "module": "$import(@zuplo/runtime)",
-  "options": {
-    "meters": { "api_requests": 1 }
+[
+  {
+    "name": "monetization-standard",
+    "policyType": "monetization-inbound",
+    "handler": {
+      "export": "MonetizationInboundPolicy",
+      "module": "$import(@zuplo/runtime)",
+      "options": {
+        "meters": { "api_requests": 1 }
+      }
+    }
+  },
+  {
+    "name": "monetization-ai",
+    "policyType": "monetization-inbound",
+    "handler": {
+      "export": "MonetizationInboundPolicy",
+      "module": "$import(@zuplo/runtime)",
+      "options": {
+        "meters": { "api_requests": 1, "tokens": 1 }
+      }
+    }
+  },
+  {
+    "name": "monetization-premium",
+    "policyType": "monetization-inbound",
+    "handler": {
+      "export": "MonetizationInboundPolicy",
+      "module": "$import(@zuplo/runtime)",
+      "options": {
+        "meters": { "api_credits": 10 }
+      }
+    }
   }
-}
-```
-
-`monetization-ai`:
-
-```json
-{
-  "export": "MonetizationInboundPolicy",
-  "module": "$import(@zuplo/runtime)",
-  "options": {
-    "meters": { "api_requests": 1, "tokens": 1 }
-  }
-}
-```
-
-`monetization-premium`:
-
-```json
-{
-  "export": "MonetizationInboundPolicy",
-  "module": "$import(@zuplo/runtime)",
-  "options": {
-    "meters": { "api_credits": 10 }
-  }
-}
+]
 ```
 
 Apply each to the appropriate routes:

--- a/docs/articles/monetization/monetization-policy.md
+++ b/docs/articles/monetization/monetization-policy.md
@@ -19,25 +19,24 @@ and allows or blocks access.
 
 ## Basic configuration
 
-Add the policy to your `policies.json`:
+Add the policy in the Zuplo Portal under **Code → policies.json → Create Policy
+→ Monetization**. The policy editor shows the handler block:
 
 ```json
 {
-  "name": "monetization-inbound",
-  "policyType": "monetization-inbound",
-  "handler": {
-    "export": "MonetizationInboundPolicy",
-    "module": "$import(@zuplo/runtime)",
-    "options": {
-      "meters": {
-        "api_requests": 1
-      }
+  "export": "MonetizationInboundPolicy",
+  "module": "$import(@zuplo/runtime)",
+  "options": {
+    "meters": {
+      "api_requests": 1
     }
   }
 }
 ```
 
-Then reference it in your route's inbound policy pipeline:
+The Portal saves this as a named entry inside `policies.json`, with the `name`
+and `policyType` fields filled in for you. Reference the policy from your
+route's inbound pipeline:
 
 ```json
 {
@@ -53,8 +52,8 @@ Then reference it in your route's inbound policy pipeline:
 
 The `MonetizationInboundPolicy` handles API key authentication internally. It
 reads the API key from the `Authorization` header, validates it, and sets
-`request.user`. You do not need a separate `api-key-auth` policy on monetized
-routes — the monetization policy replaces it.
+`request.user`. You do not need a separate API key authentication policy
+(`api-key-inbound`) on monetized routes — the monetization policy replaces it.
 
 :::
 
@@ -62,7 +61,7 @@ routes — the monetization policy replaces it.
 
 | Option               | Type               | Default           | Description                                       |
 | -------------------- | ------------------ | ----------------- | ------------------------------------------------- |
-| `meters`             | object             | (required)        | Map of meter keys to increment values             |
+| `meters`             | object             | _(none)_          | Map of meter keys to increment values             |
 | `meterOnStatusCodes` | string or number[] | `"200-299"`       | Status code range to meter                        |
 | `authHeader`         | string             | `"authorization"` | Header to read the API key from                   |
 | `authScheme`         | string             | `"Bearer"`        | Expected auth scheme prefix                       |
@@ -71,7 +70,13 @@ routes — the monetization policy replaces it.
 ### `meters`
 
 The `meters` option defines which meters to increment and by how much when a
-request is processed. Values must be positive numbers.
+request is processed. Values must be non-negative numbers.
+
+If `meters` is omitted, the policy still authenticates the API key and validates
+the subscription's payment status, but no usage is recorded. If `meters` is
+provided, it must contain at least one entry — an empty object throws a
+configuration error. To track usage at runtime instead of from static config,
+see [Dynamic metering](#dynamic-metering).
 
 ```json
 // Increment the api_requests meter by 1 per request
@@ -143,53 +148,57 @@ When payment fails, a configurable grace period (default 3 days) allows
 continued access while retries are attempted. After the grace period, access is
 blocked until payment succeeds.
 
-The grace period is configurable via metadata on the plan or customer:
+The grace period resolves in this order, with each level overriding the one
+below it:
 
-- Plan metadata key: `zuplo_max_payment_overdue_days`
-- Customer metadata key: `zuplo_max_payment_overdue_days`
-- Default: `3` (days)
+1. **Customer metadata** — `zuplo_max_payment_overdue_days` on the customer
+2. **Plan metadata** — `zuplo_max_payment_overdue_days` on the plan
+3. **Bucket configuration** — `maxPaymentOverdueDays` on the bucket's
+   monetization configuration (PUT
+   `/v3/metering/{bucketId}/monetization-configuration`)
+4. **Default** — `3` days
+
+Set the value to `0` to block requests immediately when payment is overdue.
 
 ## Multiple policies for different routes
 
-Different routes can have different metering configurations. Define multiple
-policy instances:
+Different routes can have different metering configurations. Create one policy
+per configuration in the Portal — each one is a separate handler block:
+
+`monetization-standard`:
 
 ```json
-[
-  {
-    "name": "monetization-standard",
-    "policyType": "monetization-inbound",
-    "handler": {
-      "export": "MonetizationInboundPolicy",
-      "module": "$import(@zuplo/runtime)",
-      "options": {
-        "meters": { "api_requests": 1 }
-      }
-    }
-  },
-  {
-    "name": "monetization-ai",
-    "policyType": "monetization-inbound",
-    "handler": {
-      "export": "MonetizationInboundPolicy",
-      "module": "$import(@zuplo/runtime)",
-      "options": {
-        "meters": { "api_requests": 1, "tokens": 1 }
-      }
-    }
-  },
-  {
-    "name": "monetization-premium",
-    "policyType": "monetization-inbound",
-    "handler": {
-      "export": "MonetizationInboundPolicy",
-      "module": "$import(@zuplo/runtime)",
-      "options": {
-        "meters": { "api_credits": 10 }
-      }
-    }
+{
+  "export": "MonetizationInboundPolicy",
+  "module": "$import(@zuplo/runtime)",
+  "options": {
+    "meters": { "api_requests": 1 }
   }
-]
+}
+```
+
+`monetization-ai`:
+
+```json
+{
+  "export": "MonetizationInboundPolicy",
+  "module": "$import(@zuplo/runtime)",
+  "options": {
+    "meters": { "api_requests": 1, "tokens": 1 }
+  }
+}
+```
+
+`monetization-premium`:
+
+```json
+{
+  "export": "MonetizationInboundPolicy",
+  "module": "$import(@zuplo/runtime)",
+  "options": {
+    "meters": { "api_credits": 10 }
+  }
+}
 ```
 
 Apply each to the appropriate routes:
@@ -284,17 +293,20 @@ the RFC 7807 Problem Details format:
 
 Common error details:
 
-| Condition                 | `detail` message                                                    |
-| ------------------------- | ------------------------------------------------------------------- |
-| No auth header            | `"No Authorization Header"`                                         |
-| Wrong auth scheme         | `"Invalid Authorization Scheme"`                                    |
-| Invalid API key           | `"API Key is invalid or does not have access to the API"`           |
-| Expired API key           | `"API Key has expired."`                                            |
-| Expired subscription      | `"API Key has an expired subscription."`                            |
-| Payment not made          | `"Payment has not been made."`                                      |
-| Payment overdue           | `"Payment is overdue. Please update your payment method."`          |
-| Quota exhausted           | `"API Key has exceeded the allowed limit for \"X\" meter."`         |
-| Meter not in subscription | `"API Key does not have \"X\" meter provided by the subscription."` |
+| Condition                       | `detail` message                                                    |
+| ------------------------------- | ------------------------------------------------------------------- |
+| No auth header                  | `"No Authorization Header"`                                         |
+| Wrong auth scheme               | `"Invalid Authorization Scheme"`                                    |
+| Empty key after the auth scheme | `"No key present"`                                                  |
+| Cached invalid key or 401       | `"Authorization Failed"`                                            |
+| Invalid API key                 | `"API Key is invalid or does not have access to the API"`           |
+| Expired API key                 | `"API Key has expired."`                                            |
+| Expired subscription            | `"API Key has an expired subscription."`                            |
+| Subscription has no payment     | `"Subscription payment status is not available."`                   |
+| Payment not made                | `"Payment has not been made."`                                      |
+| Payment overdue                 | `"Payment is overdue. Please update your payment method."`          |
+| Quota exhausted                 | `"API Key has exceeded the allowed limit for \"X\" meter."`         |
+| Meter not in subscription       | `"API Key does not have \"X\" meter provided by the subscription."` |
 
 ## Pipeline ordering
 

--- a/docs/articles/monetization/private-plans.md
+++ b/docs/articles/monetization/private-plans.md
@@ -107,6 +107,15 @@ curl -X POST "https://dev.zuplo.com/v3/metering/${ZUPLO_BUCKET_ID}/plans" \
 
 Save the returned `id` — you need it to publish and invite users.
 
+:::note
+
+The plan `id` is a 26-character ULID (regex
+`^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$`), separate from the human-friendly
+`key` you set on creation. The publish, invite, and other plan-scoped endpoints
+require the `id`, not the `key`.
+
+:::
+
 The key difference from a public plan is `metadata.zuplo_private_plan` set to
 `"true"`. Everything else (rate cards, entitlements, pricing) works the same as
 public plans.

--- a/docs/articles/monetization/quickstart.md
+++ b/docs/articles/monetization/quickstart.md
@@ -284,21 +284,26 @@ directory.
 3. In the **Meters** configuration field, set the key to `api_requests` with a
    value of `1` to match the meter you created in _Step 4_. This field maps the
    meter slug to the number of units each request consumes.
+4. Click on **Create Policy**.
+
+The Portal saves the policy to `policies.json` as a complete entry:
 
 ```json
 {
-  "export": "MonetizationInboundPolicy",
-  "module": "$import(@zuplo/runtime)",
-  "options": {
-    "cacheTtlSeconds": 60,
-    "meters": {
-      "api_requests": 1
+  "name": "monetization-inbound",
+  "policyType": "monetization-inbound",
+  "handler": {
+    "export": "MonetizationInboundPolicy",
+    "module": "$import(@zuplo/runtime)",
+    "options": {
+      "cacheTtlSeconds": 60,
+      "meters": {
+        "api_requests": 1
+      }
     }
   }
 }
 ```
-
-4. Click on **Create Policy**.
 
 ### Apply the policy to routes
 

--- a/docs/articles/monetization/quickstart.md
+++ b/docs/articles/monetization/quickstart.md
@@ -317,7 +317,8 @@ Next, you need to apply the Monetization policy to some or all of your routes.
 :::note
 
 The `MonetizationInboundPolicy` handles API key authentication internally. You
-do not need a separate `api-key-auth` policy on monetized routes.
+do not need a separate API key authentication policy (`api-key-inbound`) on
+monetized routes.
 
 :::
 

--- a/docs/articles/monetization/stripe-integration.md
+++ b/docs/articles/monetization/stripe-integration.md
@@ -44,6 +44,15 @@ metering. Stripe is the source of truth for payment state.
 3. Enter a **Name** and paste your **Stripe API Key**
 4. Click **Save**
 
+:::tip
+
+To script the same flow (CI, infrastructure-as-code, etc.) use the
+[Stripe setup API](./api-access.mdx#stripe-setup-and-billing-readiness) — it
+exposes `POST /setup/stripe`, `GET /billing-readiness`, and key-rotation
+endpoints with the same prefix validation as the UI.
+
+:::
+
 The connection authorizes Zuplo to manage Stripe objects on your behalf —
 specifically Customers, Checkout Sessions, Customer Portal Sessions, Invoices,
 and Tax Calculations. See
@@ -190,12 +199,17 @@ cycle.
 
 ### Cancellation
 
-When a customer cancels:
+When a customer cancels through the Developer Portal:
 
-1. The subscription is set to cancel at the end of the current billing period
-   (by default)
+1. The subscription is scheduled to cancel at the end of the current billing
+   period (the portal sends `timing: "next_billing_cycle"`)
 2. The customer retains access until their current billing period ends
 3. At period end, access is revoked and the API key stops working
+
+For programmatic cancellation, see
+[Cancellation](./subscription-lifecycle.md#cancellation) in the Subscription
+Lifecycle guide — the API endpoint accepts an optional `timing` parameter and
+cancels immediately when none is provided.
 
 ## Proration
 
@@ -227,8 +241,11 @@ Stripe retries the payment.
 | `failed`        | Access blocked after grace period (configurable) |
 | `uncollectible` | Access blocked                                   |
 
-The grace period is configurable via `zuplo_max_payment_overdue_days` metadata
-on the plan or customer (default: 3 days).
+The grace period is configurable, with customer metadata overriding plan
+metadata, which overrides the bucket-level `maxPaymentOverdueDays`. Default is 3
+days. See
+[Subscription and payment validation](./monetization-policy.md#subscription-and-payment-validation)
+for the full resolution order.
 
 ## Customer portal
 
@@ -265,13 +282,14 @@ After connecting Stripe and publishing plans:
 1. Open your Developer Portal
 2. Subscribe to a plan using test card `4242 4242 4242 4242`
 3. Verify in Stripe Dashboard:
-   - Customer created
-   - Subscription active
-   - Product and Price match your plan
+   - A **Customer** is created under **Customers**
+   - A **Checkout Session** appears for the subscribe flow
+   - At the end of the billing period, an **Invoice** is created under
+     **Invoices**
 4. Make API requests and verify:
    - Requests succeed within quota
    - `403 Forbidden` returned when quota exceeded (hard limit plans)
    - Usage visible in the Developer Portal dashboard
 5. Cancel the subscription and verify:
-   - Access revoked after billing period
-   - Stripe subscription shows canceled
+   - Access is revoked at the end of the billing period
+   - The subscription is marked as canceled in the Developer Portal

--- a/docs/articles/monetization/subscription-lifecycle.md
+++ b/docs/articles/monetization/subscription-lifecycle.md
@@ -27,8 +27,9 @@ trials, upgrades, downgrades, cancellation, and reactivation.
 :::note
 
 Access is also governed by payment status. If a payment is overdue beyond the
-grace period (default 3 days, configurable via `zuplo_max_payment_overdue_days`
-metadata), access is blocked even for active subscriptions.
+grace period (default 3 days), access is blocked even for active subscriptions.
+The grace period is configurable per-customer, per-plan, or per-bucket — see
+[Subscription and payment validation](./monetization-policy.md#subscription-and-payment-validation).
 
 :::
 
@@ -56,14 +57,17 @@ curl -X POST https://dev.zuplo.com/v3/metering/{bucketId}/subscriptions \
   -H "Authorization: Bearer {API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
-    "customerId": "cus_abc123",
-    "planKey": "pro",
-    "stripeCustomerId": "cus_stripe_xyz"
+    "plan": { "key": "pro" },
+    "customerId": "01J9ZX2A8R0K8H6VG2C1A0K3WP"
   }'
 ```
 
-The `customerId` is the user's identifier in your auth system (Auth0 user ID,
-etc.). The `stripeCustomerId` is the customer's ID in Stripe.
+`plan` references the target plan by its `key` (and optionally `version`).
+Provide either `customerId` (the OpenMeter customer ULID, format
+`^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$`) or `customerKey` (your own
+identifier). Optional fields include `timing` (`"immediate"` by default,
+`"next_billing_cycle"`, or an RFC 3339 timestamp), `startingPhase`, `name`,
+`description`, `metadata`, `alignment`, and `billingAnchor`.
 
 ## Free trials
 
@@ -185,14 +189,23 @@ Customers can change plans from the Subscriptions page in the Developer Portal:
 
 ### Programmatic (API)
 
+Plan changes go through the dedicated `change` endpoint, which closes the
+current subscription and starts a new one on the target plan:
+
 ```bash
-curl -X PATCH https://dev.zuplo.com/v3/metering/{bucketId}/subscriptions/{subscriptionId} \
+curl -X POST https://dev.zuplo.com/v3/metering/{bucketId}/subscriptions/{subscriptionId}/change \
   -H "Authorization: Bearer {API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
-    "planKey": "enterprise"
+    "timing": "immediate",
+    "plan": { "key": "enterprise" }
   }'
 ```
+
+`timing` accepts `"immediate"`, `"next_billing_cycle"`, or an RFC 3339
+timestamp. To preview the proration credit before committing, call
+`POST /v3/metering/{bucketId}/subscriptions/{subscriptionId}/change/estimate-credit`
+with the same body.
 
 ### Proration behavior
 
@@ -255,8 +268,20 @@ Customers can cancel from the Developer Portal subscriptions page:
 
 ```bash
 curl -X POST https://dev.zuplo.com/v3/metering/{bucketId}/subscriptions/{subscriptionId}/cancel \
-  -H "Authorization: Bearer {API_KEY}"
+  -H "Authorization: Bearer {API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "timing": "next_billing_cycle"
+  }'
 ```
+
+`timing` controls when the cancellation takes effect:
+
+- Omitted (or `"immediate"`) — the subscription is canceled immediately and
+  access stops right away. Use this for refund-style flows.
+- `"next_billing_cycle"` — access continues until the end of the current billing
+  period, then is revoked. This matches the Developer Portal default.
+- An RFC 3339 timestamp — schedule cancellation at a specific time.
 
 ### Cancellation behavior
 
@@ -276,14 +301,9 @@ curl -X POST https://dev.zuplo.com/v3/metering/{bucketId}/subscriptions/{subscri
   -H "Authorization: Bearer {API_KEY}"
 ```
 
-This removes the pending cancellation. The subscription continues as normal.
-
-A fully canceled subscription (past the period end) can be restored:
-
-```bash
-curl -X POST https://dev.zuplo.com/v3/metering/{bucketId}/subscriptions/{subscriptionId}/restore \
-  -H "Authorization: Bearer {API_KEY}"
-```
+This removes the pending cancellation. The subscription continues as normal. For
+a subscription whose period has already ended, create a new subscription on the
+same plan instead.
 
 ## Multiple subscriptions
 

--- a/docs/articles/monetization/troubleshooting.md
+++ b/docs/articles/monetization/troubleshooting.md
@@ -30,8 +30,11 @@ announced.
      -H "Authorization: Bearer {API_KEY}"
    ```
 
-   Fix: Either resolve the payment issue in Stripe, or adjust the grace period
-   via `zuplo_max_payment_overdue_days` metadata on the plan or customer.
+   Fix: Either resolve the payment issue in Stripe, or adjust the grace period.
+   The window resolves customer metadata → plan metadata → bucket configuration
+   → 3-day default. See
+   [Subscription and payment validation](./monetization-policy.md#subscription-and-payment-validation)
+   for details.
 
 2. **Customer is using the wrong API key.** Each subscription generates its own
    key. If the customer has multiple subscriptions or regenerated their key,


### PR DESCRIPTION
## Summary

Cross-checked the monetization docs against three repositories (core/runtime, gateway-service, openmeter) following internal feedback ([thread](https://zuplo.slack.com/archives/C05V43L5H1A/p1778102433206499)). Corrected factual drift, brought the API examples in line with the real schemas, and documented two endpoint families that were entirely missing.

## Factual corrections

- **`index.mdx`** — quota-exhaustion response is `403 Forbidden`, not `429`. The policy uses `HttpProblems.forbidden` for every error condition.
- **`meters.mdx`** — CloudEvent `subject` is the subscription ULID (not `"customer-id"`), matching `policy.ts:454-465`. Both `subject` and `subscription` carry the same value.
- **`monetization-policy.md`**:
  - `meters` option is optional (not required); values are non-negative (not positive).
  - Added three missing rows to the error-detail table: `"No key present"`, `"Authorization Failed"`, `"Subscription payment status is not available."`
  - Standardized the policy snippets to the flat handler-block form to match what the Portal editor shows.
- **`subscription-lifecycle.md`** — rewrote the create-subscription, plan-change, and cancel API examples against the real OpenMeter payload shapes:
  - Create uses `plan: { key }` plus `customerId` (ULID) **or** `customerKey` — there is no `stripeCustomerId` field.
  - Plan changes go through `POST /subscriptions/{id}/change` with `{ timing, plan: { key } }`, not `PATCH /subscriptions/{id}`.
  - Cancel takes a `timing` body; the API default is **immediate** (the Developer Portal explicitly sends `next_billing_cycle`).
  - Removed the deprecated `/restore` endpoint (past its 2025-10-06 EOL).
- **`stripe-integration.md`** — corrected the "Verifying the integration" steps to reference the objects Zuplo actually creates in Stripe (Customer, Checkout Session, Invoice) rather than Subscriptions/Products/Prices.
- **`private-plans.md`** — added a note clarifying the plan `id` is a 26-char ULID (`^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$`), distinct from the human-friendly `key`.
- **`quickstart.md`**, **`monetization-policy.md`** — referenced the actual policy name (`api-key-inbound`) instead of the made-up `api-key-auth`.

## Documentation gaps filled

- **Bucket monetization configuration** in `api-access.mdx` — `GET`/`PUT`/`DELETE` `/v3/metering/{bucketId}/monetization-configuration` with the four supported fields (`multipleSubscriptionsEnabled`, `planOrder`, `planSettings.visiblePhases`, `maxPaymentOverdueDays`).
- **Stripe setup and billing readiness APIs** in `api-access.mdx` — `POST /setup/stripe`, `GET /setup/stripe`, `POST /setup/stripe/{appId}/billing-profile`, `GET /billing-readiness`, `PUT /apps/{appId}` with key-prefix validation rules.
- **Bucket-level `maxPaymentOverdueDays`** as the third level in the grace-period resolution chain (customer → plan → bucket → 3-day default) in `monetization-policy.md`, with cross-references from `stripe-integration.md`, `subscription-lifecycle.md`, and `troubleshooting.md`.

## Notes for reviewers

- I documented `multipleSubscriptionsEnabled` carefully: the field is settable on the bucket but **not yet read** by `HasReachedMaxActiveSubscriptions` in `gateway-service` (still uses `maxActiveSubscriptions := 1` with a TODO). The doc describes it as "stored on the bucket … reserved for future enforcement" rather than claiming behavior the code doesn't yet provide.
- The `popular` plan-metadata flag in `developer-portal.md:92-95` has no implementation that I could find. Per the planning notes, this represents intended behavior with a missing implementation, so the doc text was left as-is and should be raised separately.

## Test plan

- [x] `pnpm prettier --check docs/articles/monetization/` passes
- [ ] Reviewer to spot-check rendered pages locally if any concern about MDX/admonition formatting
- [ ] Optional: copy a `curl` example (e.g. the `PUT /monetization-configuration` sample) and run it against a dev bucket to confirm the response matches the documented shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)