### PR TITLE
docs: add portal shortcut links for direct navigation

### DIFF
--- a/docs/ai-gateway/apps.mdx
+++ b/docs/ai-gateway/apps.mdx
@@ -12,11 +12,11 @@ API Key so that usage is tracked independently. Apps are owned by a specific
 ## API Keys
 
 Each App in the AI Gateway has its own API Key. This allows you to track usage
-independently for each App. You can find the API Key for an App by navigating to
-the **Apps** tab of your AI Gateway project in the
-[Zuplo Portal](https://portal.zuplo.com). Select the App you want to view the
-API Key for. With the App open you will see the API Key section at the top of
-the app page.
+independently for each App. You can find the API Key for an App by opening the
+[Apps](https://portal.zuplo.com/+/account/project/ai/apps) tab of your AI
+Gateway project in the Zuplo Portal. Select the App you want to view the API Key
+for. With the App open you will see the API Key section at the top of the app
+page.
 
 **Additional Resources**
 

--- a/docs/ai-gateway/custom-providers.mdx
+++ b/docs/ai-gateway/custom-providers.mdx
@@ -21,9 +21,9 @@ To add a custom AI provider to your Zuplo AI Gateway, follow these steps:
 
 <Stepper>
 
-1. Open the
-   [AI Providers settings](https://portal.zuplo.com/+/account/project/ai/settings/data-models)
-   for your AI Gateway project in the Zuplo Portal.
+1. Open
+   [**Settings → AI Providers**](https://portal.zuplo.com/+/account/project/ai/settings/data-models)
+   in your AI Gateway project in the Zuplo Portal.
 
 1. Click on the **Add Provider** button.
 
@@ -47,8 +47,8 @@ To add a custom AI provider to your Zuplo AI Gateway, follow these steps:
 
 ## Modify, Update or Delete your Custom AI Provider
 
-To modify, update, or delete an existing provider, open the
-[AI Providers settings](https://portal.zuplo.com/+/account/project/ai/settings/data-models)
+To modify, update, or delete an existing provider, open
+[**Settings → AI Providers**](https://portal.zuplo.com/+/account/project/ai/settings/data-models)
 and click the **Edit** or **Delete** icon next to the custom provider.
 
 Further information can be found in the

--- a/docs/ai-gateway/custom-providers.mdx
+++ b/docs/ai-gateway/custom-providers.mdx
@@ -21,8 +21,9 @@ To add a custom AI provider to your Zuplo AI Gateway, follow these steps:
 
 <Stepper>
 
-1. Navigate to the **Settings** > **AI Providers** section of your AI Gateway
-   project in the [Zuplo Portal](https://portal.zuplo.com).
+1. Open the
+   [AI Providers settings](https://portal.zuplo.com/+/account/project/ai/settings/data-models)
+   for your AI Gateway project in the Zuplo Portal.
 
 1. Click on the **Add Provider** button.
 
@@ -46,9 +47,9 @@ To add a custom AI provider to your Zuplo AI Gateway, follow these steps:
 
 ## Modify, Update or Delete your Custom AI Provider
 
-Existing providers can be modified, updated or deleted by navigating to the
-**Settings** > **AI Providers** section and clicking the **Edit** or **Delete**
-icon next to the custom provider you want to modify, update or delete.
+To modify, update, or delete an existing provider, open the
+[AI Providers settings](https://portal.zuplo.com/+/account/project/ai/settings/data-models)
+and click the **Edit** or **Delete** icon next to the custom provider.
 
 Further information can be found in the
 [Managing Providers](./managing-providers.mdx) guide.

--- a/docs/ai-gateway/getting-started.mdx
+++ b/docs/ai-gateway/getting-started.mdx
@@ -183,8 +183,8 @@ curl https://your-ai-gateway-url.zuplo.app/v1/chat/completions \
 
 ### Check Your Dashboard
 
-1. Open your
-   [AI Gateway Apps](https://portal.zuplo.com/+/account/project/ai/apps)
+1. Open the [**Apps**](https://portal.zuplo.com/+/account/project/ai/apps) tab
+   of your AI Gateway project
 2. Click on your app
 3. Click on **Dashboard** to view:
    - Request count

--- a/docs/ai-gateway/getting-started.mdx
+++ b/docs/ai-gateway/getting-started.mdx
@@ -183,7 +183,8 @@ curl https://your-ai-gateway-url.zuplo.app/v1/chat/completions \
 
 ### Check Your Dashboard
 
-1. Return to your AI Gateway project
+1. Open your
+   [AI Gateway Apps](https://portal.zuplo.com/+/account/project/ai/apps)
 2. Click on your app
 3. Click on **Dashboard** to view:
    - Request count

--- a/docs/ai-gateway/guardrails.mdx
+++ b/docs/ai-gateway/guardrails.mdx
@@ -49,8 +49,8 @@ When a guardrail detects a policy violation:
 
 To add guardrails to your AI Gateway:
 
-1. Navigate to the API Gateway project associated with your AI Gateway in the
-   [Zuplo Portal](https://portal.zuplo.com)
+1. Open your [project](https://portal.zuplo.com/+/account/project/) associated
+   with your AI Gateway in the Zuplo Portal
 2. Open the **Code** tab and select your `routes.oas.json` file
 3. Select the route for your AI Gateway endpoint
 4. Click **Add Policy** and search for the guardrail you want to add

--- a/docs/ai-gateway/managing-apps.mdx
+++ b/docs/ai-gateway/managing-apps.mdx
@@ -12,8 +12,8 @@ that usage is tracked independently. Apps are owned by a specific
 
 <Stepper>
 
-1. Navigate to the **Apps** tab of your AI Gateway project in the
-   [Zuplo Portal](https://portal.zuplo.com).
+1. Open the [Apps](https://portal.zuplo.com/+/account/project/ai/apps) tab of
+   your AI Gateway project in the Zuplo Portal.
 
 1. Click on the **Create App** button.
 
@@ -33,14 +33,16 @@ that usage is tracked independently. Apps are owned by a specific
 
 ## Editing an App
 
-To edit an app, navigate to the **Apps** tab of your AI Gateway project in the
-[Zuplo Portal](https://portal.zuplo.com). Select the app you want to edit.
-Select the tab you want to edit (Policies or Settings). Make your changes and
-click the **Save** button.
+To edit an app, open the
+[Apps](https://portal.zuplo.com/+/account/project/ai/apps) tab of your AI
+Gateway project in the Zuplo Portal. Select the app you want to edit. Select the
+tab you want to edit (Policies or Settings). Make your changes and click the
+**Save** button.
 
 ## Deleting an App
 
-To delete an app, navigate to the **Apps** tab of your AI Gateway project in the
-[Zuplo Portal](https://portal.zuplo.com). Select the app you want to delete and
+To delete an app, open the
+[Apps](https://portal.zuplo.com/+/account/project/ai/apps) tab of your AI
+Gateway project in the Zuplo Portal. Select the app you want to delete and
 scroll to the bottom of the page and click the **Delete App** button. You will
 be prompted to confirm the deletion.

--- a/docs/ai-gateway/managing-providers.mdx
+++ b/docs/ai-gateway/managing-providers.mdx
@@ -13,9 +13,9 @@ To add a new AI provider to your Zuplo AI Gateway, follow these steps:
 
 <Stepper>
 
-1. Open the
-   [AI Providers settings](https://portal.zuplo.com/+/account/project/ai/settings/data-models)
-   for your AI Gateway project in the Zuplo Portal.
+1. Open
+   [**Settings → AI Providers**](https://portal.zuplo.com/+/account/project/ai/settings/data-models)
+   in your AI Gateway project in the Zuplo Portal.
 
 1. Click on the **Add Provider** button.
 
@@ -45,8 +45,8 @@ To add a new AI provider to your Zuplo AI Gateway, follow these steps:
 
 ## Editing an AI Provider
 
-To modify an existing provider, open the
-[AI Providers settings](https://portal.zuplo.com/+/account/project/ai/settings/data-models)
+To modify an existing provider, open
+[**Settings → AI Providers**](https://portal.zuplo.com/+/account/project/ai/settings/data-models)
 and click the **Edit** button next to the provider you want to modify.
 
 You can modify the label, API key, and selected models for the provider. After
@@ -63,6 +63,6 @@ existing applications that rely on the provider.
 ## Deleting an AI Provider
 
 Providers that are no longer used within your project can be deleted. To delete
-a provider, open the
-[AI Providers settings](https://portal.zuplo.com/+/account/project/ai/settings/data-models)
+a provider, open
+[**Settings → AI Providers**](https://portal.zuplo.com/+/account/project/ai/settings/data-models)
 and click the **Delete** button next to the provider you want to remove.

--- a/docs/ai-gateway/managing-providers.mdx
+++ b/docs/ai-gateway/managing-providers.mdx
@@ -13,8 +13,9 @@ To add a new AI provider to your Zuplo AI Gateway, follow these steps:
 
 <Stepper>
 
-1. Navigate to the **Settings** > **AI Providers** section of your AI Gateway
-   project in the [Zuplo Portal](https://portal.zuplo.com).
+1. Open the
+   [AI Providers settings](https://portal.zuplo.com/+/account/project/ai/settings/data-models)
+   for your AI Gateway project in the Zuplo Portal.
 
 1. Click on the **Add Provider** button.
 
@@ -44,9 +45,9 @@ To add a new AI provider to your Zuplo AI Gateway, follow these steps:
 
 ## Editing an AI Provider
 
-Existing providers can be modified by navigating to the **Settings** > **AI
-Providers** section and clicking the **Edit** button next to the provider you
-want to modify.
+To modify an existing provider, open the
+[AI Providers settings](https://portal.zuplo.com/+/account/project/ai/settings/data-models)
+and click the **Edit** button next to the provider you want to modify.
 
 You can modify the label, API key, and selected models for the provider. After
 making your changes, click **Save** to apply them. Changes are effective
@@ -62,5 +63,6 @@ existing applications that rely on the provider.
 ## Deleting an AI Provider
 
 Providers that are no longer used within your project can be deleted. To delete
-a provider, navigate to the **Settings** > **AI Providers** section and click
-the **Delete** button next to the provider you want to remove.
+a provider, open the
+[AI Providers settings](https://portal.zuplo.com/+/account/project/ai/settings/data-models)
+and click the **Delete** button next to the provider you want to remove.

--- a/docs/ai-gateway/managing-teams.mdx
+++ b/docs/ai-gateway/managing-teams.mdx
@@ -10,8 +10,8 @@ also where you define usage limits.
 
 <Stepper>
 
-1. Navigate to the **Teams** tab of your AI Gateway project in the
-   [Zuplo Portal](https://portal.zuplo.com).
+1. Open the [Teams](https://portal.zuplo.com/+/account/project/ai/teams) tab of
+   your AI Gateway project in the Zuplo Portal.
 
 1. Click on the **Create Team** button.
 
@@ -28,8 +28,8 @@ and Apps associated with that team.
 
 <Stepper>
 
-1. Navigate to the **Teams** tab of your AI Gateway project in the
-   [Zuplo Portal](https://portal.zuplo.com).
+1. Open the [Teams](https://portal.zuplo.com/+/account/project/ai/teams) tab of
+   your AI Gateway project in the Zuplo Portal.
 
 1. Select the team you want to add members to.
 

--- a/docs/ai-gateway/usage-limits.mdx
+++ b/docs/ai-gateway/usage-limits.mdx
@@ -60,8 +60,9 @@ When a limit is reached, the AI Gateway can operate in two modes:
 
 Track current usage and spending through the AI Gateway dashboard:
 
-1. Open your
-   [AI Gateway analytics](https://portal.zuplo.com/+/account/project/ai/analytics)
+1. Open the
+   [**Analytics**](https://portal.zuplo.com/+/account/project/ai/analytics) tab
+   of your AI Gateway project
 2. Click on an app and select **Dashboard**
 3. View real-time metrics including:
    - Request count

--- a/docs/ai-gateway/usage-limits.mdx
+++ b/docs/ai-gateway/usage-limits.mdx
@@ -30,9 +30,9 @@ enforcement configuration.
 
 To configure daily budgets:
 
-1. Navigate to your AI Gateway project in the
-   [Zuplo Portal](https://portal.zuplo.com)
-2. Select the **Teams** or **Apps** tab
+1. Open your AI Gateway project in the Zuplo Portal
+2. Select the [Teams](https://portal.zuplo.com/+/account/project/ai/teams) or
+   [Apps](https://portal.zuplo.com/+/account/project/ai/apps) tab
 3. Click on the team or app to edit
 4. Select the **Usage & Limits** tab and configure the **Daily Budget** field
 5. Click **Save Changes**
@@ -60,7 +60,8 @@ When a limit is reached, the AI Gateway can operate in two modes:
 
 Track current usage and spending through the AI Gateway dashboard:
 
-1. Navigate to your AI Gateway project
+1. Open your
+   [AI Gateway analytics](https://portal.zuplo.com/+/account/project/ai/analytics)
 2. Click on an app and select **Dashboard**
 3. View real-time metrics including:
    - Request count
@@ -77,7 +78,8 @@ queries.
 
 To enable semantic caching:
 
-1. Navigate to the **Apps** tab and click on the app to edit
+1. Open the [Apps](https://portal.zuplo.com/+/account/project/ai/apps) tab and
+   click on the app to edit
 2. Enable the **Semantic Caching** toggle under **Advanced Features**
 3. Save your changes
 

--- a/docs/articles/accounts/audit-logs.mdx
+++ b/docs/articles/accounts/audit-logs.mdx
@@ -34,11 +34,9 @@ easy to investigate issues, track changes, and demonstrate compliance.
 ## Accessing Audit Logs
 
 Audit logs are available for accounts on the Enterprise plan. To access your
-audit logs:
-
-1. Navigate to your account settings
-2. Click on **Audit Logs** in the left sidebar
-3. View the chronological list of all account activities
+audit logs, open
+[**Account Settings → Audit Logs**](https://portal.zuplo.com/+/account/settings/audit-logs)
+in the Zuplo Portal to view the chronological list of all account activities.
 
 :::note
 

--- a/docs/articles/accounts/billing.mdx
+++ b/docs/articles/accounts/billing.mdx
@@ -3,7 +3,8 @@ title: Zuplo Billing
 sidebar_label: Billing
 ---
 
-The [**Billing**](https://portal.zuplo.com/+/account/settings/upgrade-billing)
+The
+[**Account Settings → Billing**](https://portal.zuplo.com/+/account/settings/upgrade-billing)
 page in the Zuplo dashboard allows you to subscribe to a Zuplo plan, update your
 payment method, and view your billing history.
 
@@ -15,9 +16,9 @@ Zuplo dashboard.
 ## Update Payment Method
 
 When you navigate to the
-[**Billing**](https://portal.zuplo.com/+/account/settings/upgrade-billing) page,
-you will see a link to manage your existing subscription. Clicking this link
-will take you to the Stripe checkout page where you can update your payment
+[**Account Settings → Billing**](https://portal.zuplo.com/+/account/settings/upgrade-billing)
+page, you will see a link to manage your existing subscription. Clicking this
+link will take you to the Stripe checkout page where you can update your payment
 method.
 
 :::note{title="Enterprise Plans"}

--- a/docs/articles/accounts/billing.mdx
+++ b/docs/articles/accounts/billing.mdx
@@ -3,8 +3,9 @@ title: Zuplo Billing
 sidebar_label: Billing
 ---
 
-The **Billing** page in the Zuplo dashboard allows you to subscribe to a Zuplo
-plan, update your payment method, and view your billing history.
+The [**Billing**](https://portal.zuplo.com/+/account/settings/upgrade-billing)
+page in the Zuplo dashboard allows you to subscribe to a Zuplo plan, update your
+payment method, and view your billing history.
 
 Zuplo uses Stripe to process payments. When you subscribe to a Zuplo plan, you
 will be redirected to the Stripe checkout page to enter your payment
@@ -13,9 +14,11 @@ Zuplo dashboard.
 
 ## Update Payment Method
 
-When you navigate to the **Billing** page, you will see a link to manage your
-existing subscription. Clicking this link will take you to the Stripe checkout
-page where you can update your payment method.
+When you navigate to the
+[**Billing**](https://portal.zuplo.com/+/account/settings/upgrade-billing) page,
+you will see a link to manage your existing subscription. Clicking this link
+will take you to the Stripe checkout page where you can update your payment
+method.
 
 :::note{title="Enterprise Plans"}
 

--- a/docs/articles/accounts/default-api-key.mdx
+++ b/docs/articles/accounts/default-api-key.mdx
@@ -23,9 +23,8 @@ To delete the default API key, follow these steps:
 
 {/* prettier-ignore */}
 <Stepper>
-1. Navigate to your Zuplo account settings.
-2. Click on the **API Keys** section.
-3. Locate the default API key in the list. It will be labeled "Default consumer for account-name" and have a "default" tag.
-4. Click the **Delete** button next to the default API key.
-5. Confirm the deletion when prompted.
+1. Open [**Account Settings → API Keys**](https://portal.zuplo.com/+/account/settings/api-keys) in the Zuplo Portal.
+2. Locate the default API key in the list. It will be labeled "Default consumer for account-name" and have a "default" tag.
+3. Click the **Delete** button next to the default API key.
+4. Confirm the deletion when prompted.
 </Stepper>

--- a/docs/articles/accounts/delete-account.mdx
+++ b/docs/articles/accounts/delete-account.mdx
@@ -8,19 +8,19 @@ sure you want to delete your account, follow these steps:
 
 <Stepper>
 
-1. Remove any custom domains from your projects. You can do this by going to the
-   **Custom Domains** section in your project settings and removing any custom
-   domains.
+1. Remove any custom domains from your account. You can do this from
+   [**Account Settings → Custom Domains**](https://portal.zuplo.com/+/account/settings/custom-domains).
 1. Delete all your projects. You can do this by going to the **General** tab in
    your each project settings and clicking the **Delete Project** button.
-1. Remove any additional team members from your account. You can do this by
-   going to the **Members** tab in your account settings and removing any
-   additional team members.
-1. You must also unsubscribe from any paid plans. You can do this by going to
-   the **Billing** tab in your account settings. You will need to wait until the
-   end of your billing cycle to delete your account.
-1. Once you have completed the above steps, go to the **General** tab in your
-   account settings and click the **Delete Account** button.
+1. Remove any additional team members from your account. You can do this from
+   [**Account Settings → Members**](https://portal.zuplo.com/+/account/settings/members).
+1. You must also unsubscribe from any paid plans. You can do this from
+   [**Account Settings → Billing**](https://portal.zuplo.com/+/account/settings/upgrade-billing).
+   You will need to wait until the end of your billing cycle to delete your
+   account.
+1. Once you have completed the above steps, go to
+   [**Account Settings → General**](https://portal.zuplo.com/+/account/settings/general)
+   and click the **Delete Account** button.
 1. Confirm that you want to delete your account by entering your the text shown
    in the confirmation box.
 1. Click the **Delete Account** button to permanently delete your account.

--- a/docs/articles/accounts/enterprise-sso.mdx
+++ b/docs/articles/accounts/enterprise-sso.mdx
@@ -21,8 +21,9 @@ by following the steps below.
 
 <Stepper>
 
-1. Navigate to the Account Settings section in the Zuplo portal.
-1. Open the "Security" tab.
+1. Open
+   [**Account Settings → Security**](https://portal.zuplo.com/+/account/settings/security)
+   in the Zuplo Portal.
 1. In the section labeled "Single Sign On (SSO)", click the "Setup Single
    Sign-On" button.
 1. This will open a new window hosted by Auth0 that allows you to configure SSO
@@ -39,7 +40,8 @@ by following the steps below.
 
 If you need to edit your SSO configuration after the initial setup, you can do
 so by clicking the "Edit Connection" button in the "Single Sign On (SSO)"
-section of the Security tab in Account Settings.
+section of
+[**Account Settings → Security**](https://portal.zuplo.com/+/account/settings/security).
 
 This will open the Auth0 configuration window where you can make changes to your
 connection settings. This is useful if you need to rotate certificates or client

--- a/docs/articles/accounts/managing-account-members.mdx
+++ b/docs/articles/accounts/managing-account-members.mdx
@@ -8,9 +8,9 @@ manage users in your account.
 
 ## Add Account Member
 
-To start, navigate to the account settings page by clicking your user icon in
-the top right corner of the screen and selecting **Settings** from the dropdown
-menu.
+To start, open
+[**Account Settings → Members**](https://portal.zuplo.com/+/account/settings/members)
+in the Zuplo Portal.
 
 The view will display the users that are currently members of the account and
 their roles.

--- a/docs/articles/accounts/zuplo-api-keys.mdx
+++ b/docs/articles/accounts/zuplo-api-keys.mdx
@@ -12,10 +12,10 @@ accessible areas such as GitHub repositories.
 
 ## Creating an API Key
 
-To start, navigate to the account settings page by clicking your user icon in
-the top right corner of the screen and selecting "Settings" from the dropdown
-menu. Click the **API Keys** tab to view the API keys in your account that you
-have access to.
+Open
+[**Account Settings → API Keys**](https://portal.zuplo.com/+/account/settings/api-keys)
+in the Zuplo Portal to view the API keys in your account that you have access
+to.
 
 ![API Keys](../../../public/media/zuplo-api-keys/image.png)
 
@@ -26,8 +26,10 @@ only view their own API keys. Members don't have access to API keys.
 
 :::
 
-Select the "Create API Key" button to create a new API key. You can enter a
-label, expiration, and select the permissions for your new API key.
+Select the
+[**Create API Key**](https://portal.zuplo.com/+/account/settings/api-keys/create)
+button to create a new API key. You can enter a label, expiration, and select
+the permissions for your new API key.
 
 <EnterpriseFeature name="Fine-grained API Key Management" />
 

--- a/docs/articles/api-key-administration.mdx
+++ b/docs/articles/api-key-administration.mdx
@@ -3,7 +3,8 @@ title: Manage Keys in the Portal
 sidebar_label: Manage in the Portal
 ---
 
-API Key Consumers can be managed in the Zuplo Portal's **Services** section.
+API Key Consumers can be managed in the Zuplo Portal's
+[**Services**](https://portal.zuplo.com/+/account/project/services) section.
 Each project is created with three API Key Buckets - one for production, one
 shared by preview environments, and one for development (working copy)
 environments.
@@ -40,7 +41,9 @@ or more managers, via e-mail, to be a manager for your API Key Consumer. This is
 optional if you aren't using the
 [Developer Portal](../dev-portal/introduction.mdx).
 
-You can assign managers in the Zuplo Portal (portal.zuplo.com) or via the API.
+You can assign managers from your project's
+[Services](https://portal.zuplo.com/+/account/project/services) page in the
+Zuplo Portal or via the API.
 
 If you want to automatically create an API Key for a customer automatically when
 they sign into your developer portal using Auth0,

--- a/docs/articles/api-key-administration.mdx
+++ b/docs/articles/api-key-administration.mdx
@@ -3,11 +3,11 @@ title: Manage Keys in the Portal
 sidebar_label: Manage in the Portal
 ---
 
-API Key Consumers can be managed in the Zuplo Portal's
-[**Services**](https://portal.zuplo.com/+/account/project/services) section.
-Each project is created with three API Key Buckets - one for production, one
-shared by preview environments, and one for development (working copy)
-environments.
+API Key Consumers can be managed from your project's
+[**Services**](https://portal.zuplo.com/+/account/project/services) page in the
+Zuplo Portal. Each project is created with three API Key Buckets - one for
+production, one shared by preview environments, and one for development (working
+copy) environments.
 
 ![Services](../../public/media/api-key-administration/services-page.png)
 

--- a/docs/articles/api-key-end-users.mdx
+++ b/docs/articles/api-key-end-users.mdx
@@ -43,9 +43,10 @@ hand in the admin portal does not scale to a production user base.
 :::
 
 For development or one-off needs, the easiest way to obtain an API key is in the
-[Zuplo Portal](https://portal.zuplo.com). Open **Services > API Key Service**,
-click **Configure**, and you can view existing keys or create new keys for your
-consumers manually.
+[Zuplo Portal](https://portal.zuplo.com). Open
+[**Services**](https://portal.zuplo.com/+/account/project/services), find the
+**API Key Service**, click **Configure**, and you can view existing keys or
+create new keys for your consumers manually.
 
 ![API key section](../../public/media/api-key-end-users/api-key-service.png)
 

--- a/docs/articles/api-key-end-users.mdx
+++ b/docs/articles/api-key-end-users.mdx
@@ -43,9 +43,9 @@ hand in the admin portal does not scale to a production user base.
 :::
 
 For development or one-off needs, the easiest way to obtain an API key is in the
-[Zuplo Portal](https://portal.zuplo.com). Open
-[**Services**](https://portal.zuplo.com/+/account/project/services), find the
-**API Key Service**, click **Configure**, and you can view existing keys or
+[Zuplo Portal](https://portal.zuplo.com). Open your project's
+[**Services**](https://portal.zuplo.com/+/account/project/services) page, find
+the **API Key Service**, click **Configure**, and you can view existing keys or
 create new keys for your consumers manually.
 
 ![API key section](../../public/media/api-key-end-users/api-key-service.png)

--- a/docs/articles/api-key-self-serve-integration.mdx
+++ b/docs/articles/api-key-self-serve-integration.mdx
@@ -48,11 +48,15 @@ Before you start, you need:
   [API Key Authentication policy](../policies/api-key-inbound.mdx) configured on
   your routes.
 - A **Zuplo API key** for the Developer API. Create one in the Zuplo Portal
-  under **Settings > Zuplo API Keys**.
+  under
+  [**Account Settings → Zuplo API Keys**](https://portal.zuplo.com/+/account/settings/api-keys).
   [More information](./accounts/zuplo-api-keys).
 - Your **account name** and **bucket name**. A bucket groups consumers for an
   environment - each project has buckets for production, preview, and
-  development. Find these in the Zuplo Portal under **Settings > General**.
+  development. Find the bucket name on your project's
+  [**Services**](https://portal.zuplo.com/+/account/project/services) page, and
+  the account name in
+  [**Project Settings → General**](https://portal.zuplo.com/+/account/project/settings/general).
 - An application with server-side code and existing user authentication.
 
 All examples in this guide use these environment variables:
@@ -60,9 +64,9 @@ All examples in this guide use these environment variables:
 ```bash
 # Your Zuplo Account Name
 export ZUPLO_ACCOUNT=my-account
-# Your bucket name (found in Settings > General)
+# Your bucket name (found on your project's Services page)
 export ZUPLO_BUCKET=my-bucket
-# Your Zuplo API Key (found in Settings > Zuplo API Keys)
+# Your Zuplo API Key (found in Account Settings > Zuplo API Keys)
 export ZUPLO_API_KEY=zpka_YOUR_API_KEY
 ```
 

--- a/docs/articles/branch-based-deployments.mdx
+++ b/docs/articles/branch-based-deployments.mdx
@@ -107,16 +107,18 @@ git push -u origin my-new-feature
 ```
 
 Within seconds, Zuplo deploys a new environment named `my-new-feature`. You can
-see the new environment in the Zuplo Portal's environment selector or the
-[Environments](https://portal.zuplo.com/+/account/project/environments) page.
+see the new environment in the Zuplo Portal's environment selector or on the
+[**Environments**](https://portal.zuplo.com/+/account/project/environments) tab
+of your project.
 
 ## Deleting Environments
 
 When you delete a branch in your Git repository, the corresponding Zuplo
 environment is **not automatically deleted**. To delete an environment:
 
-1. Open [Environments](https://portal.zuplo.com/+/account/project/environments)
-   in the Zuplo Portal
+1. In your project, open the
+   [**Environments**](https://portal.zuplo.com/+/account/project/environments)
+   tab
 2. Select the environment and delete it
 
 Alternatively, use the [Zuplo CLI](../cli/delete.mdx):

--- a/docs/articles/branch-based-deployments.mdx
+++ b/docs/articles/branch-based-deployments.mdx
@@ -107,16 +107,17 @@ git push -u origin my-new-feature
 ```
 
 Within seconds, Zuplo deploys a new environment named `my-new-feature`. You can
-see the new environment in the Zuplo portal's environment selector.
+see the new environment in the Zuplo Portal's environment selector or the
+[Environments](https://portal.zuplo.com/+/account/project/environments) page.
 
 ## Deleting Environments
 
 When you delete a branch in your Git repository, the corresponding Zuplo
 environment is **not automatically deleted**. To delete an environment:
 
-1. Go to the Zuplo portal
-2. Navigate to **Settings** > **Environments**
-3. Select the environment and delete it
+1. Open [Environments](https://portal.zuplo.com/+/account/project/environments)
+   in the Zuplo Portal
+2. Select the environment and delete it
 
 Alternatively, use the [Zuplo CLI](../cli/delete.mdx):
 

--- a/docs/articles/custom-ci-cd-azure.mdx
+++ b/docs/articles/custom-ci-cd-azure.mdx
@@ -51,8 +51,9 @@ CLI outputs `Deployed to https://...` which you can parse with `grep` or `sed`.
 
 1. **Disconnect Git integration** — If you're using Azure Pipelines for
    deployments, disconnect the native Git integration to avoid duplicate
-   deployments. Go to **Settings** > **Source Control** and click
-   **Disconnect**.
+   deployments. Open your
+   [project settings](https://portal.zuplo.com/+/account/project/settings/general),
+   select **Source Control**, and click **Disconnect**.
 
 2. **Add your API key** — Store your Zuplo API key as a pipeline variable or in
    a variable group. Go to **Pipelines** > **Library** to create a variable

--- a/docs/articles/custom-ci-cd-bitbucket.mdx
+++ b/docs/articles/custom-ci-cd-bitbucket.mdx
@@ -50,8 +50,9 @@ and mark it as an artifact for subsequent steps.
 
 1. **Disconnect Git integration** — If you're using Bitbucket Pipelines for
    deployments, disconnect the native Git integration to avoid duplicate
-   deployments. Go to **Settings** > **Source Control** and click
-   **Disconnect**.
+   deployments. Open your
+   [project settings](https://portal.zuplo.com/+/account/project/settings/general),
+   select **Source Control**, and click **Disconnect**.
 
 2. **Add your API key** — Store your Zuplo API key as a repository variable. Go
    to **Repository settings** > **Repository variables** and add

--- a/docs/articles/custom-ci-cd-circleci.mdx
+++ b/docs/articles/custom-ci-cd-circleci.mdx
@@ -48,8 +48,10 @@ in the deploy job and attach the workspace for the test job.
 ## Prerequisites
 
 1. **Disconnect Git integration** — If you're using CircleCI for deployments,
-   disconnect the native Git integration to avoid duplicate deployments. Go to
-   **Settings** > **Source Control** and click **Disconnect**.
+   disconnect the native Git integration to avoid duplicate deployments. Open
+   your
+   [project settings](https://portal.zuplo.com/+/account/project/settings/general),
+   select **Source Control**, and click **Disconnect**.
 
 2. **Add your API key** — Store your Zuplo API key as an environment variable.
    Go to **Project Settings** > **Environment Variables** and add

--- a/docs/articles/custom-ci-cd-github.mdx
+++ b/docs/articles/custom-ci-cd-github.mdx
@@ -67,11 +67,13 @@ use throughout your workflow.
 ## Prerequisites
 
 1. **Disconnect the GitHub integration** — Custom CI/CD replaces automatic
-   deployments. Go to **Settings** > **Source Control** and click **Disconnect**
-   to prevent double deployments.
+   deployments. Open your
+   [project settings](https://portal.zuplo.com/+/account/project/settings/general),
+   select **Source Control**, and click **Disconnect** to prevent double
+   deployments.
 
 2. **Add your API key** — Store your Zuplo API key as a GitHub secret named
-   `ZUPLO_API_KEY`. Find your key in the Zuplo portal under your account
+   `ZUPLO_API_KEY`. Find your key in the Zuplo Portal under your account
    **Settings** > **API Keys**.
 
 ## Examples

--- a/docs/articles/custom-ci-cd-gitlab.mdx
+++ b/docs/articles/custom-ci-cd-gitlab.mdx
@@ -49,8 +49,9 @@ in the deploy job and retrieve it in the test job.
 
 1. **Disconnect Git integration** — If you're using GitLab CI/CD for
    deployments, disconnect the native Git integration to avoid duplicate
-   deployments. Go to **Settings** > **Source Control** and click
-   **Disconnect**.
+   deployments. Open your
+   [project settings](https://portal.zuplo.com/+/account/project/settings/general),
+   select **Source Control**, and click **Disconnect**.
 
 2. **Add your API key** — Store your Zuplo API key as a CI/CD variable. Go to
    **Settings** > **CI/CD** > **Variables** and add `ZUPLO_API_KEY`. Check

--- a/docs/articles/custom-ci-cd.mdx
+++ b/docs/articles/custom-ci-cd.mdx
@@ -54,9 +54,9 @@ trivial to implement.
 :::warning{title="GitHub Users: Disconnect Automatic Deployments"}
 
 If you're using GitHub with custom CI/CD, disconnect the built-in integration to
-prevent double deployments:
-
-**Settings** > **Source Control** > **Disconnect**
+prevent double deployments. Open your
+[project settings](https://portal.zuplo.com/+/account/project/settings/general),
+select **Source Control**, and click **Disconnect**.
 
 GitLab, Bitbucket, and Azure DevOps don't have automatic deployments, so no
 disconnection is needed.
@@ -65,11 +65,9 @@ disconnection is needed.
 
 ## Getting Your API Key
 
-The CLI authenticates with an API key:
-
-1. Go to [portal.zuplo.com](https://portal.zuplo.com)
-2. Select your account
-3. Navigate to **Settings** > **API Keys**
+The CLI authenticates with an API key. Open
+[**Account Settings → API Keys**](https://portal.zuplo.com/+/account/settings/api-keys)
+in the Zuplo Portal to create one.
 
 Store this as a secret in your CI/CD provider (typically `ZUPLO_API_KEY`). Never
 commit API keys to your repository.

--- a/docs/articles/custom-domains.mdx
+++ b/docs/articles/custom-domains.mdx
@@ -5,8 +5,9 @@ sidebar_label: Overview
 
 This guide will walk you through the process of setting up a custom domain for
 your project's edge deployment environment. You can manage all domain settings
-related to a project in the **Custom Domains** section of **Settings** for your
-project. Custom Domains are available on
+in the
+[**Custom Domains**](https://portal.zuplo.com/+/account/settings/custom-domains)
+section of your account settings. Zuplo offers Custom Domains on
 [Builder plans and above](https://zuplo.com/pricing).
 
 ## Types of Custom Domains
@@ -36,11 +37,12 @@ environment is development if the domain ends with `zuplo.dev`.
 The following steps will guide you on how to add and configure a custom domain
 for your Zuplo project.
 
-### 1. Navigate to your project's Custom Domain Settings
+### 1. Navigate to your Custom Domain Settings
 
-Go to your project in the Zuplo portal, click **Settings** (1), then select
-**Custom Domains** (2) and click the **Add New Custom Domain** button to open
-the `New Custom Domain` configuration modal.
+Open
+[**Account Settings → Custom Domains**](https://portal.zuplo.com/+/account/settings/custom-domains)
+in the Zuplo Portal and click the **Add New Custom Domain** button to open the
+`New Custom Domain` configuration modal.
 
 ![Custom Domain](../../public/media/custom-domains/image.png)
 

--- a/docs/articles/environments.mdx
+++ b/docs/articles/environments.mdx
@@ -101,8 +101,9 @@ relate to each other, see
 On the bottom toolbar of the Zuplo Portal you will see a selector for the
 current environment. You can switch between environments by clicking on the name
 of the current environment and then selecting another environment. To see the
-full list, open
-[Environments](https://portal.zuplo.com/+/account/project/environments).
+full list, open the
+[**Environments**](https://portal.zuplo.com/+/account/project/environments) tab
+in your project.
 
 ![Environments](../../public/media/environments/image.png)
 

--- a/docs/articles/environments.mdx
+++ b/docs/articles/environments.mdx
@@ -98,9 +98,11 @@ relate to each other, see
 
 ## Navigating Environments
 
-On the bottom toolbar of the Zuplo portal you will see a selector for the
+On the bottom toolbar of the Zuplo Portal you will see a selector for the
 current environment. You can switch between environments by clicking on the name
-of the current environment and then selecting another environment.
+of the current environment and then selecting another environment. To see the
+full list, open
+[Environments](https://portal.zuplo.com/+/account/project/environments).
 
 ![Environments](../../public/media/environments/image.png)
 

--- a/docs/articles/mcp-quickstart.mdx
+++ b/docs/articles/mcp-quickstart.mdx
@@ -13,8 +13,8 @@ If you're not familiar with Zuplo, it's recommended to go through the
 
 1. Create a **new project**
 
-   Sign in to [portal.zuplo.com](https://portal.zuplo.com) and create a new
-   project.
+   Sign in to the Zuplo Portal and
+   [create a new project](https://portal.zuplo.com/+/account/projects/new).
 
 1. **Import** an **OpenAPI** document
 

--- a/docs/articles/migrate-from-kong.md
+++ b/docs/articles/migrate-from-kong.md
@@ -221,8 +221,8 @@ Replace Kong's JWT plugin with one of Zuplo's JWT authentication policies:
 
 ### Step 5: Set up your project and deploy
 
-1. Create a new project in the [Zuplo Portal](https://portal.zuplo.com/signup)
-   or using the [Zuplo CLI](../cli/overview.md).
+1. [Create a new project](https://portal.zuplo.com/+/account/projects/new) in
+   the Zuplo Portal or using the [Zuplo CLI](../cli/overview.md).
 2. Import your OpenAPI spec as the route configuration file.
 3. Add policies to your routes.
 4. Connect your project to [source control](./source-control.md).

--- a/docs/articles/monetization/api-access.mdx
+++ b/docs/articles/monetization/api-access.mdx
@@ -46,9 +46,10 @@ are set in your terminal:
 
 ```bash
 # Your Bucket ID (could be working-copy, preview, or production)
-# (Found in Project Services > Bucket Details)
+# (Found in Project Services > Bucket Details — https://portal.zuplo.com/+/account/project/services)
 export BUCKET_ID=your-bucket-id
-# Your Zuplo API Key (Found in Account Settings > Zuplo API Keys)
+# Your Zuplo API Key (Found in Account Settings > Zuplo API Keys —
+# https://portal.zuplo.com/+/account/settings/api-keys)
 export ZAPI_KEY=zpka_YOUR_API_KEY
 ```
 

--- a/docs/articles/monetization/developer-portal.md
+++ b/docs/articles/monetization/developer-portal.md
@@ -76,8 +76,10 @@ Save and deploy. Once the plugin is enabled, ensure:
 
 ### Plan display order
 
-Control plan display order in the Zuplo Portal under **Services →
-Monetization**. Plans can be reordered using drag-and-drop.
+Control plan display order from your project's
+[**Services**](https://portal.zuplo.com/+/account/project/services) page in the
+Zuplo Portal — open the Monetization Service. Plans can be reordered using
+drag-and-drop.
 
 ### Feature comparison matrix
 
@@ -158,7 +160,9 @@ use the same fonts, colors, and layout as the rest of your portal.
 The Developer Portal runs at `https://your-project.zuplo.dev/docs` by default.
 For production, configure a custom domain:
 
-1. Navigate to **Settings → Custom Domains** in the Zuplo Portal
+1. Open
+   [**Account Settings → Custom Domains**](https://portal.zuplo.com/+/account/settings/custom-domains)
+   in the Zuplo Portal
 2. Add your domain (e.g., `developers.your-company.com`)
 3. Configure the DNS records as instructed
 4. SSL is provisioned automatically

--- a/docs/articles/monetization/quickstart.md
+++ b/docs/articles/monetization/quickstart.md
@@ -46,7 +46,7 @@ keeps your existing work safe from any breaking changes.
 :::
 
 1. Go to [portal.zuplo.com](https://portal.zuplo.com) and sign in.
-2. Click **New Project** in the top right corner.
+2. [Create a new project](https://portal.zuplo.com/+/account/projects/new).
 3. Enter a **Project name** or use the randomly chosen name Zuplo provides.
 4. Select **Starter Project (Recommended)** — it comes with endpoints ready to
    monetize.
@@ -83,7 +83,8 @@ Add the monetization plugin to your Developer Portal configuration.
 
 ## Step 3: Configure the Monetization Service
 
-1. Navigate to the **Services** tab in your project.
+1. Open the [**Services**](https://portal.zuplo.com/+/account/project/services)
+   tab in your project.
 2. Select the environment you want to configure. We will use **Working Copy**
    for this quickstart.
 3. Click **Configure** on the **Monetization Service** card.

--- a/docs/articles/monetization/quickstart.md
+++ b/docs/articles/monetization/quickstart.md
@@ -46,7 +46,8 @@ keeps your existing work safe from any breaking changes.
 :::
 
 1. Go to [portal.zuplo.com](https://portal.zuplo.com) and sign in.
-2. [Create a new project](https://portal.zuplo.com/+/account/projects/new).
+2. Click **New Project** in the top right corner
+   ([open](https://portal.zuplo.com/+/account/projects/new)).
 3. Enter a **Project name** or use the randomly chosen name Zuplo provides.
 4. Select **Starter Project (Recommended)** — it comes with endpoints ready to
    monetize.

--- a/docs/articles/monetization/stripe-integration.md
+++ b/docs/articles/monetization/stripe-integration.md
@@ -42,7 +42,8 @@ in Stripe at the moment a charge is needed (as invoice line items).
 
 ### Via the Zuplo Portal
 
-1. Open [**Services**](https://portal.zuplo.com/+/account/project/services),
+1. Open your project's
+   [**Services**](https://portal.zuplo.com/+/account/project/services) page,
    select the Monetization Service, then go to **Payment Provider**
 2. Click **Configure** on the Stripe card
 3. Enter a **Name** and paste your **Stripe API Key**
@@ -113,8 +114,9 @@ Intents, Refunds, or Stripe Billing Meters — leave all of those at **None**.
 3. For each of the eight permissions above, set the level shown in the table.
 4. Click **Create key**, copy the value (`rk_test_...` or `rk_live_...`), and
    paste it into the Monetization Service's **Payment Provider** screen (open
-   [**Services**](https://portal.zuplo.com/+/account/project/services), then the
-   Monetization Service) in your Zuplo project.
+   your project's
+   [**Services**](https://portal.zuplo.com/+/account/project/services) page,
+   then the Monetization Service) in your Zuplo project.
 
 :::caution
 

--- a/docs/articles/monetization/stripe-integration.md
+++ b/docs/articles/monetization/stripe-integration.md
@@ -42,7 +42,8 @@ in Stripe at the moment a charge is needed (as invoice line items).
 
 ### Via the Zuplo Portal
 
-1. Navigate to **Services → Monetization Service → Payment Provider**
+1. Open [**Services**](https://portal.zuplo.com/+/account/project/services),
+   select the Monetization Service, then go to **Payment Provider**
 2. Click **Configure** on the Stripe card
 3. Enter a **Name** and paste your **Stripe API Key**
 4. Click **Save**
@@ -111,8 +112,9 @@ Intents, Refunds, or Stripe Billing Meters — leave all of those at **None**.
    or `Zuplo Monetization (production)`.
 3. For each of the eight permissions above, set the level shown in the table.
 4. Click **Create key**, copy the value (`rk_test_...` or `rk_live_...`), and
-   paste it into **Services → Monetization Service → Payment Provider** in your
-   Zuplo project.
+   paste it into the Monetization Service's **Payment Provider** screen (open
+   [**Services**](https://portal.zuplo.com/+/account/project/services), then the
+   Monetization Service) in your Zuplo project.
 
 :::caution
 
@@ -208,22 +210,22 @@ When a customer cancels through the Developer Portal, the timing of the
 cancellation depends on whether the current phase has billable items:
 
 - **Paid phases** — the portal sends `timing: "next_billing_cycle"`. The
-  subscription is scheduled to cancel at the end of the current billing
-  period, the customer retains access until then, and the API key stops
-  working at period end.
+  subscription is scheduled to cancel at the end of the current billing period,
+  the customer retains access until then, and the API key stops working at
+  period end.
 - **Free phases** — the portal sends `timing: "immediate"`. With nothing to
   invoice at period end, there's no billing period to wait out, so the
   subscription cancels and access is revoked right away. Two situations fall
   into this branch:
-  - The customer is on a **free trial phase** (the first phase of a plan
-    with a later paid phase) and cancels before the trial converts.
-  - The customer is on a **free plan** — a plan whose only phase has no
-    billable rate cards (every rate card's `price` is `null`).
+  - The customer is on a **free trial phase** (the first phase of a plan with a
+    later paid phase) and cancels before the trial converts.
+  - The customer is on a **free plan** — a plan whose only phase has no billable
+    rate cards (every rate card's `price` is `null`).
 
 For programmatic cancellation, see
 [Cancellation](./subscription-lifecycle.md#cancellation) in the Subscription
-Lifecycle guide — the API endpoint accepts a `timing` parameter to control
-this same behavior explicitly.
+Lifecycle guide — the API endpoint accepts a `timing` parameter to control this
+same behavior explicitly.
 
 ## Proration
 

--- a/docs/articles/monorepo-deployment.mdx
+++ b/docs/articles/monorepo-deployment.mdx
@@ -220,8 +220,7 @@ jobs:
 
 Store your Zuplo API key as a GitHub Actions secret:
 
-1. Go to [portal.zuplo.com](https://portal.zuplo.com) and navigate to your
-   account **Settings** > **API Keys**
+1. In the Zuplo Portal, navigate to your account **Settings** > **API Keys**
 2. Copy the API key
 3. In your GitHub repository, go to **Settings** > **Secrets and variables** >
    **Actions**
@@ -322,7 +321,7 @@ the deployed environment. Timeouts can indicate:
   `routes.oas.json` or `policies.json` exist in the `modules/` directory
 - **Missing environment variables** — If your policies or handlers reference
   environment variables with `$env(VAR_NAME)`, make sure those variables are
-  configured in the Zuplo portal under your project's
+  configured in the Zuplo Portal under your project's
   [environment variables](./environment-variables.mdx)
 
 ### Build succeeds but deploy fails

--- a/docs/articles/source-control-setup-github.mdx
+++ b/docs/articles/source-control-setup-github.mdx
@@ -18,10 +18,12 @@ new Zuplo project.
 
 1. Connect to GitHub
 
-   Go to your project in the Zuplo portal, click **Settings**, then select
-   **Source Control**. If your project isn't already connected to GitHub click
-   the **Connect to GitHub** button and follow the auth flow. You'll need to
-   grant permissions for any GitHub organizations you want to work with.
+   Open your
+   [project settings](https://portal.zuplo.com/+/account/project/settings/general)
+   in the Zuplo Portal, then select **Source Control**. If your project isn't
+   already connected to GitHub click the **Connect to GitHub** button and follow
+   the auth flow. You'll need to grant permissions for any GitHub organizations
+   you want to work with.
 
    ![Connect GitHub](../../public/media/step-4-deploying-to-the-edge/image-1.png)
 

--- a/docs/articles/step-1-setup-basic-gateway.mdx
+++ b/docs/articles/step-1-setup-basic-gateway.mdx
@@ -18,9 +18,9 @@ Note - Zuplo also supports building and running your API locally. To learn more
 
 1. **Sign-in**
 
-   Sign in to [portal.zuplo.com](https://portal.zuplo.com) and create a free
-   account. Create a new **empty** project (don't import an existing project,
-   we'll set up git later). Then...
+   Sign in to the Zuplo Portal and create a free account. Then
+   [create a new empty project](https://portal.zuplo.com/+/account/projects/new)
+   (don't import an existing project, we'll set up git later). Then...
 
 1. Add your first **Route**
 

--- a/docs/articles/step-3-add-api-key-auth-local.mdx
+++ b/docs/articles/step-3-add-api-key-auth-local.mdx
@@ -102,9 +102,10 @@ Let's get started.
 
 1.  Set up an API Key
 
-    In order to call your API, you need to configure an API consumer. Go to the
-    [Zuplo Portal](https://portal.zuplo.com), then open the project you are
-    working on, **Services**, then click **Configure** on the "API Key Service".
+    In order to call your API, you need to configure an API consumer. Open
+    [Services](https://portal.zuplo.com/+/account/project/services) for your
+    project in the Zuplo Portal, then click **Configure** on the "API Key
+    Service".
 
     :::warning
 

--- a/docs/articles/step-3-add-api-key-auth-local.mdx
+++ b/docs/articles/step-3-add-api-key-auth-local.mdx
@@ -102,10 +102,10 @@ Let's get started.
 
 1.  Set up an API Key
 
-    In order to call your API, you need to configure an API consumer. Open
-    [Services](https://portal.zuplo.com/+/account/project/services) for your
-    project in the Zuplo Portal, then click **Configure** on the "API Key
-    Service".
+    In order to call your API, you need to configure an API consumer. In the
+    Zuplo Portal, open the
+    [**Services**](https://portal.zuplo.com/+/account/project/services) tab for
+    your project, then click **Configure** on the "API Key Service".
 
     :::warning
 

--- a/docs/articles/step-3-add-api-key-auth.mdx
+++ b/docs/articles/step-3-add-api-key-auth.mdx
@@ -70,7 +70,8 @@ Let's get started.
 2. Set up an API Key
 
    In order to call your API, you need to configure an API consumer. Go to
-   **Services**, then click **Configure** on the "API Key Service".
+   [Services](https://portal.zuplo.com/+/account/project/services), then click
+   **Configure** on the "API Key Service".
 
    ![API Key Service](../../public/media/step-3-add-api-key-auth/image-2.png)
 

--- a/docs/articles/step-3-add-api-key-auth.mdx
+++ b/docs/articles/step-3-add-api-key-auth.mdx
@@ -69,9 +69,9 @@ Let's get started.
 
 2. Set up an API Key
 
-   In order to call your API, you need to configure an API consumer. Go to
-   [Services](https://portal.zuplo.com/+/account/project/services), then click
-   **Configure** on the "API Key Service".
+   In order to call your API, you need to configure an API consumer. Open the
+   [**Services**](https://portal.zuplo.com/+/account/project/services) tab in
+   your project, then click **Configure** on the "API Key Service".
 
    ![API Key Service](../../public/media/step-3-add-api-key-auth/image-2.png)
 

--- a/docs/articles/step-4-deploying-to-the-edge.mdx
+++ b/docs/articles/step-4-deploying-to-the-edge.mdx
@@ -30,10 +30,12 @@ Let's get started:
 
 1. Authorize to GitHub
 
-   Next, go to your project in the Zuplo portal, click **Settings**, then select
-   **Source Control**. If your project isn't already connected to GitHub click
-   the **Connect to GitHub** button and follow the auth flow. You'll need to
-   grant permissions for any GitHub organizations you want to work with.
+   Next, open your
+   [project settings](https://portal.zuplo.com/+/account/project/settings/general)
+   in the Zuplo Portal, then select **Source Control**. If your project isn't
+   already connected to GitHub click the **Connect to GitHub** button and follow
+   the auth flow. You'll need to grant permissions for any GitHub organizations
+   you want to work with.
 
    ![Connect GitHub](../../public/media/step-4-deploying-to-the-edge/image-1.png)
 

--- a/docs/articles/testing.mdx
+++ b/docs/articles/testing.mdx
@@ -78,11 +78,10 @@ The `.env.zuplo` file can contain sensitive information. Add it to your
 :::
 
 Once linked, services like the API Key Authentication policy work locally using
-the same API key bucket as the linked environment. You can create API key
-consumers under
-[Services](https://portal.zuplo.com/+/account/project/services) > **API Key
-Service** in the Zuplo Portal, then call your local gateway with the generated
-key:
+the same API key bucket as the linked environment. In the Zuplo Portal, open the
+[**Services**](https://portal.zuplo.com/+/account/project/services) tab in your
+project and select **API Key Service** to create API key consumers, then call
+your local gateway with the generated key:
 
 ```bash
 curl http://localhost:9000/your-route \

--- a/docs/articles/testing.mdx
+++ b/docs/articles/testing.mdx
@@ -79,8 +79,10 @@ The `.env.zuplo` file can contain sensitive information. Add it to your
 
 Once linked, services like the API Key Authentication policy work locally using
 the same API key bucket as the linked environment. You can create API key
-consumers in the [Zuplo Portal](https://portal.zuplo.com) under **Services > API
-Key Service**, then call your local gateway with the generated key:
+consumers under
+[Services](https://portal.zuplo.com/+/account/project/services) > **API Key
+Service** in the Zuplo Portal, then call your local gateway with the generated
+key:
 
 ```bash
 curl http://localhost:9000/your-route \

--- a/docs/articles/troubleshooting.md
+++ b/docs/articles/troubleshooting.md
@@ -79,9 +79,10 @@ arrays.
 The gateway returns this error when the project has a critical configuration
 issue that prevents it from starting.
 
-**Fix:** Check the deployment logs in the Zuplo Portal for the specific error
-message. Common causes include invalid `zuplo.runtime.ts` configuration or
-broken runtime extensions.
+**Fix:** Check the deployment logs in the Zuplo Portal under
+[Environments](https://portal.zuplo.com/+/account/project/environments) for the
+specific error message. Common causes include invalid `zuplo.runtime.ts`
+configuration or broken runtime extensions.
 
 ### MAIN_MOD_ERROR
 
@@ -174,9 +175,10 @@ const response = await fetch("https://api.example.com/data", {
 
 ### Portal live logs
 
-The Zuplo Portal provides real-time log viewing for deployed environments.
-Navigate to your project in the portal and open the logs tab to see live request
-logs and any messages logged with `context.log`.
+The Zuplo Portal provides real-time log viewing for deployed environments. Open
+[Environments](https://portal.zuplo.com/+/account/project/environments), select
+the deployed environment, and open the logs tab to see live request logs and any
+messages logged with `context.log`.
 
 ### Using context.log
 

--- a/docs/articles/troubleshooting.md
+++ b/docs/articles/troubleshooting.md
@@ -79,10 +79,11 @@ arrays.
 The gateway returns this error when the project has a critical configuration
 issue that prevents it from starting.
 
-**Fix:** Check the deployment logs in the Zuplo Portal under
-[Environments](https://portal.zuplo.com/+/account/project/environments) for the
-specific error message. Common causes include invalid `zuplo.runtime.ts`
-configuration or broken runtime extensions.
+**Fix:** Check the deployment logs in the Zuplo Portal — open the
+[**Environments**](https://portal.zuplo.com/+/account/project/environments) tab
+in your project and select the failing environment to see the specific error
+message. Common causes include invalid `zuplo.runtime.ts` configuration or
+broken runtime extensions.
 
 ### MAIN_MOD_ERROR
 
@@ -176,9 +177,9 @@ const response = await fetch("https://api.example.com/data", {
 ### Portal live logs
 
 The Zuplo Portal provides real-time log viewing for deployed environments. Open
-[Environments](https://portal.zuplo.com/+/account/project/environments), select
-the deployed environment, and open the logs tab to see live request logs and any
-messages logged with `context.log`.
+the [**Environments**](https://portal.zuplo.com/+/account/project/environments)
+tab in your project, select the deployed environment, and open the logs tab to
+see live request logs and any messages logged with `context.log`.
 
 ### Using context.log
 

--- a/docs/cli/authentication.mdx
+++ b/docs/cli/authentication.mdx
@@ -37,9 +37,10 @@ following these steps:
 
 1. Navigate to [portal.zuplo.com](https://portal.zuplo.com) and log in.
 2. Select the account that you want to work on.
-3. Open [API Keys](https://portal.zuplo.com/+/account/settings/api-keys) under
-   your account settings. Select an existing API Key or create a new one to use
-   with the CLI.
+3. Navigate to
+   [**Settings → API Keys**](https://portal.zuplo.com/+/account/settings/api-keys)
+   in your account. Select an existing API Key or create a new one to use with
+   the CLI.
 
 Most commands take an `--api-key` argument. For example, to list your available
 Zuplo API Gateways, run:

--- a/docs/cli/authentication.mdx
+++ b/docs/cli/authentication.mdx
@@ -37,8 +37,9 @@ following these steps:
 
 1. Navigate to [portal.zuplo.com](https://portal.zuplo.com) and log in.
 2. Select the account that you want to work on.
-3. Click the **Settings** tab and navigate to the "API Keys" section. Select an
-   existing API Key or create a new one to use with the CLI.
+3. Open [API Keys](https://portal.zuplo.com/+/account/settings/api-keys) under
+   your account settings. Select an existing API Key or create a new one to use
+   with the CLI.
 
 Most commands take an `--api-key` argument. For example, to list your available
 Zuplo API Gateways, run:

--- a/docs/cli/deploy.partial.mdx
+++ b/docs/cli/deploy.partial.mdx
@@ -43,4 +43,5 @@ POLL_INTERVAL=5000 MAX_POLL_RETRIES=300 zuplo deploy
 ```
 
 Note, that even if the CLI times out, the deployment will continue. You can
-check the status of the deployment in the Zuplo portal.
+check the status of the deployment in your
+[project](https://portal.zuplo.com/+/account/project/) in the Zuplo Portal.

--- a/docs/concepts/api-keys.md
+++ b/docs/concepts/api-keys.md
@@ -23,7 +23,8 @@ The API key system has three core objects:
 See [API Key Management](../articles/api-key-management.mdx) for a full
 overview, and
 [Manage Keys in the Portal](../articles/api-key-administration.mdx) for managing
-consumers in the portal.
+consumers under [Services](https://portal.zuplo.com/+/account/project/services)
+in your project.
 
 ## How validation works
 
@@ -76,8 +77,8 @@ when the consumer's key is used. Common uses:
   backend
 - **Organization**: `{"orgId": 456}` for multi-tenant routing
 
-Metadata is set when creating a consumer via the
-[portal](../articles/api-key-administration.mdx),
+Set metadata when creating a consumer via the
+[portal](https://portal.zuplo.com/+/account/project/services),
 [Developer API](../articles/api-key-api.mdx), or
 [developer portal self-serve](#self-serve-key-management).
 
@@ -173,11 +174,11 @@ self-serve API key management. Your API consumers can sign in to the portal and
 create, view, and delete their own keys without contacting your team.
 
 To enable self-serve access, assign a **manager** to a consumer. Managers are
-identified by email and identity provider subject. This can be done in the
-portal, via the [Developer API](../articles/api-key-api.mdx), or automatically
-when a user signs in using
-[Auth0](../dev-portal/dev-portal-create-consumer-on-auth.mdx) or another
-identity provider.
+identified by email and identity provider subject. You can assign a manager in
+the [portal](https://portal.zuplo.com/+/account/project/services), via the
+[Developer API](../articles/api-key-api.mdx), or automatically when a user signs
+in using [Auth0](../dev-portal/dev-portal-create-consumer-on-auth.mdx) or
+another identity provider.
 
 ## Buckets and environments
 

--- a/docs/concepts/authentication.mdx
+++ b/docs/concepts/authentication.mdx
@@ -48,9 +48,9 @@ reference.
 
 Zuplo's built-in [API key management](../articles/api-key-management.mdx)
 provides a complete system for issuing, managing, and validating API keys.
-Create consumers (API key holders) via the
-[portal](https://portal.zuplo.com/+/account/project/services), API, or developer
-portal self-serve.
+Create consumers (API key holders) under
+[**Services**](https://portal.zuplo.com/+/account/project/services) in your
+project, via the API, or via developer portal self-serve.
 
 Best for: B2B APIs, developer platforms, and any API where you manage consumer
 access.

--- a/docs/concepts/authentication.mdx
+++ b/docs/concepts/authentication.mdx
@@ -48,7 +48,8 @@ reference.
 
 Zuplo's built-in [API key management](../articles/api-key-management.mdx)
 provides a complete system for issuing, managing, and validating API keys.
-Consumers (API key holders) can be created via the portal, API, or developer
+Create consumers (API key holders) via the
+[portal](https://portal.zuplo.com/+/account/project/services), API, or developer
 portal self-serve.
 
 Best for: B2B APIs, developer platforms, and any API where you manage consumer

--- a/docs/concepts/source-control-and-deployment.mdx
+++ b/docs/concepts/source-control-and-deployment.mdx
@@ -210,7 +210,9 @@ The typical workflow from development to production looks like this:
   <DiagramEdge from="merge" to="production" />
 </Diagram>
 
-1. **Develop** locally with `zuplo dev` or in the portal working copy.
+1. **Develop** locally with `zuplo dev` or in your
+   [project's working copy](https://portal.zuplo.com/+/account/project/) in the
+   Zuplo Portal.
 2. **Push** your changes to a feature branch. If using GitHub, a Preview
    environment deploys automatically. If using another provider, your CI/CD
    pipeline runs `zuplo deploy`.

--- a/docs/guides/canary-routing-for-employees.mdx
+++ b/docs/guides/canary-routing-for-employees.mdx
@@ -203,7 +203,9 @@ export const percentageCanaryRoutingPolicy: InboundPolicyHandler = async (
 
 ### Environment Variables
 
-Configure your environment variables in the Zuplo dashboard:
+Configure your
+[environment variables](https://portal.zuplo.com/+/account/project/environments)
+in the Zuplo Portal:
 
 ```bash
 # List of employee emails or user IDs

--- a/docs/guides/canary-routing-for-employees.mdx
+++ b/docs/guides/canary-routing-for-employees.mdx
@@ -203,9 +203,9 @@ export const percentageCanaryRoutingPolicy: InboundPolicyHandler = async (
 
 ### Environment Variables
 
-Configure your
-[environment variables](https://portal.zuplo.com/+/account/project/environments)
-in the Zuplo Portal:
+Configure environment variables under the
+[**Environments**](https://portal.zuplo.com/+/account/project/environments) tab
+of your project in the Zuplo Portal:
 
 ```bash
 # List of employee emails or user IDs

--- a/docs/guides/user-based-backend-routing.mdx
+++ b/docs/guides/user-based-backend-routing.mdx
@@ -77,8 +77,9 @@ export default async function policy(
 }
 ```
 
-When creating API keys in the Zuplo portal, set the metadata to include the
-environment:
+When creating API keys under
+[Services](https://portal.zuplo.com/+/account/project/services) in the Zuplo
+Portal, set the metadata to include the environment:
 
 ```json
 {

--- a/docs/programmable-api/environment.mdx
+++ b/docs/programmable-api/environment.mdx
@@ -313,12 +313,12 @@ context.log.info("Config loaded", {
 
 ## Setting Environment Variables
 
-Environment variables are set in the Zuplo Portal:
+Set environment variables in the Zuplo Portal:
 
-1. Navigate to your project
-2. Go to Settings → Environment Variables
-3. Add variables for each environment (production, preview, development)
-4. Variables are encrypted at rest and in transit
+1. Open your
+   [project's environments](https://portal.zuplo.com/+/account/project/environments).
+2. Select an environment and add variables under Environment Variables.
+3. Zuplo encrypts variables at rest and in transit.
 
 ## See Also
 

--- a/docs/programmable-api/environment.mdx
+++ b/docs/programmable-api/environment.mdx
@@ -315,9 +315,10 @@ context.log.info("Config loaded", {
 
 Set environment variables in the Zuplo Portal:
 
-1. Open your
-   [project's environments](https://portal.zuplo.com/+/account/project/environments).
-2. Select an environment and add variables under Environment Variables.
+1. Open the
+   [**Environments**](https://portal.zuplo.com/+/account/project/environments)
+   tab of your project.
+2. Select an environment and add variables under **Environment Variables**.
 3. Zuplo encrypts variables at rest and in transit.
 
 ## See Also

--- a/docs/programmable-api/zuplo-context.mdx
+++ b/docs/programmable-api/zuplo-context.mdx
@@ -89,9 +89,9 @@ context.log.info({
 ### `log`
 
 A logger instance for debugging and monitoring. Logs appear in your log tail in
-the portal and in your integrated log solution (for example Datadog).
-Pre-production environments are typically set to **Info** log level, while
-production is set to **Error**.
+the [Zuplo Portal](https://portal.zuplo.com/+/account/project/) and in your
+integrated log solution (for example Datadog). Pre-production environments are
+typically set to **Info** log level, while production is set to **Error**.
 
 :::tip
 


### PR DESCRIPTION
## Summary

Use the new `/+/account` and `/+/account/project` shortcut URLs from [zuplo/portal#4740](https://github.com/zuplo/portal/pull/4740) throughout the docs so readers can jump straight to the right portal page without us knowing their account or project slugs.

## What changed

50 docs touched. A team of agents scanned each docs section and replaced "navigate to Settings → Members" / "go to your project's environments" / etc. with direct shortcut links the user can click.

**Most-linked targets:**
- `/+/account/project/services` (17×) — API key, monetization, and metering buckets
- `/+/account/project/settings/general` (9×) — project settings
- `/+/account/project/environments` (7×) — environments list
- `/+/account/project/ai/apps` (7×) — AI Gateway apps
- `/+/account/settings/api-keys` (5×) — Zuplo API keys
- `/+/account/project/ai/settings/data-models` (5×) — AI providers/models
- `/+/account/settings/custom-domains` (4×)
- `/+/account/projects/new` (4×)
- Plus billing, members, security/SSO, audit logs, AI teams/analytics

**Coverage by area:**
- AI Gateway: all 8 navigation-relevant `.mdx` files
- Articles/accounts: all 7 (audit logs, billing, default API key, delete account, SSO, members, Zuplo API keys)
- Articles/monetization: 4 (quickstart, api-access, dev-portal, stripe-integration)
- API key flows: api-key-administration, api-key-end-users, api-key-self-serve-integration, custom-domains
- CI/CD & deployment: 7 files (custom-ci-cd + 5 platform variants, source-control-setup-github, branch-based-deployments, environments, monorepo-deployment)
- Tutorials: step-1, step-3 (both variants), step-4, mcp-quickstart, migrate-from-kong, testing, troubleshooting
- CLI / concepts / programmable-api / guides: 9 files

## Rules followed

- Only added links where prose already directs the reader to a specific page in the portal.
- Only used paths that exist as real routes in the portal — no invented paths.
- Stopped at the parent page when the destination requires a slug (specific environment, build, bucket).
- Skipped error pages, code blocks, screenshot references, generic "sign in" mentions, and the public Developer Portal docs (different product).

## Test plan

- [ ] Spot-check rendered docs to confirm shortcut links resolve correctly when logged in (e.g., `/+/account/settings/upgrade-billing` → user's account billing page)
- [ ] Verify links still read naturally — link text matches the navigation target name
- [ ] Verify lefthook/prettier pass (already passed locally on commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)