### PR TITLE
docs(dev-portal): add Zuplo guide for documenting external MCP servers

### DIFF
--- a/docs/dev-portal/documenting-mcp-servers.mdx
+++ b/docs/dev-portal/documenting-mcp-servers.mdx
@@ -1,0 +1,223 @@
+---
+title: Documenting MCP Servers
+sidebar_label: Documenting MCP Servers
+navigation_icon: bot
+description:
+  Use the x-mcp-server OpenAPI extension to render an MCP setup card in the Dev
+  Portal for external or proxied MCP servers.
+---
+
+The Dev Portal renders a dedicated
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io/) setup UI for
+any OpenAPI operation that includes the `x-mcp-server` extension. The card
+replaces the standard request/response view with the MCP endpoint URL, a copy
+button, and tabbed installation instructions for Claude, ChatGPT, Cursor, VS
+Code, and a generic config.
+
+:::tip{title="Building an MCP server on Zuplo?"}
+
+If your MCP server uses Zuplo's
+[MCP Server Handler](/docs/handlers/mcp-server.mdx), the `x-mcp-server`
+extension is added to your OpenAPI spec automatically. Skip this guide — there
+is nothing to configure. See the
+[MCP Server overview](/docs/mcp-server/introduction.mdx) for the build path.
+
+:::
+
+## When to use this guide
+
+Use this guide when you want to surface an MCP server in your Dev Portal that
+you are **not** building with Zuplo's MCP Server Handler. Common scenarios:
+
+- You proxy a third-party MCP server through a Zuplo route (for example, with a
+  [URL forward](/docs/handlers/url-forward.mdx) or
+  [custom handler](/docs/handlers/custom-handler.mdx)) and want to publish setup
+  instructions for it.
+- You hand-author an OpenAPI spec for an MCP server hosted outside Zuplo.
+- You catalog multiple MCP servers — some yours, some external — in a single Dev
+  Portal.
+
+In every case, this guide covers only the **documentation** side: how the Dev
+Portal renders the MCP card. Authentication, rate limiting, and any other
+gateway behavior is configured on the underlying route as usual.
+
+## Adding the extension
+
+Add `x-mcp-server` to the operation that represents the MCP endpoint. MCP
+servers typically use `POST`, but the extension works on any HTTP method.
+
+```json title="openapi.json"
+{
+  "paths": {
+    "/mcp": {
+      "post": {
+        "summary": "Acme Docs MCP",
+        "description": "MCP endpoint for searching Acme's documentation.",
+        "operationId": "acmeDocsMcp",
+        "x-mcp-server": {
+          "name": "acme-docs",
+          "version": "1.0.0",
+          "tools": [
+            {
+              "name": "search_docs",
+              "description": "Search the documentation"
+            },
+            {
+              "name": "get_page",
+              "description": "Retrieve a specific documentation page"
+            }
+          ]
+        },
+        "responses": {
+          "200": {
+            "description": "MCP response"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+For a quick setup with no metadata, use the shorthand `"x-mcp-server": true`.
+The operation `summary` is then used as the server name.
+
+## Extension properties
+
+| Property  | Type     | Required | Description                                                                                                          |
+| --------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------- |
+| `name`    | `string` | No       | Display name used in the generated client config snippets. Falls back to the operation `summary`, then `mcp-server`. |
+| `version` | `string` | No       | Version metadata. Included for completeness; not currently rendered in the UI.                                       |
+| `tools`   | `array`  | No       | Tool metadata. Used by Zuplo enrichment; not currently rendered in the UI.                                           |
+
+Each entry in `tools` accepts:
+
+| Property      | Type     | Required | Description                     |
+| ------------- | -------- | -------- | ------------------------------- |
+| `name`        | `string` | Yes      | Tool name                       |
+| `description` | `string` | No       | Human-readable tool description |
+
+## MCP URL resolution
+
+The displayed MCP URL is constructed from the **server URL** of the API plus the
+**path** of the operation. The server URL comes from the OpenAPI `servers` array
+(or the operation-level `servers` override, when present).
+
+For example:
+
+```json
+{
+  "servers": [{ "url": "https://api.example.com" }],
+  "paths": {
+    "/mcp/docs": {
+      "post": {
+        "x-mcp-server": { "name": "docs-mcp" },
+        "responses": { "200": { "description": "OK" } }
+      }
+    }
+  }
+}
+```
+
+The displayed MCP URL is `https://api.example.com/mcp/docs`. Make sure the
+server URL points to wherever the MCP server actually accepts requests — for
+proxied servers, that is typically your Zuplo gateway URL.
+
+## Complete example
+
+This minimal but complete OpenAPI spec produces an MCP endpoint page in the Dev
+Portal:
+
+```json title="mcp-api.json"
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Acme Docs MCP",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.example.com",
+      "description": "Production"
+    }
+  ],
+  "paths": {
+    "/mcp": {
+      "post": {
+        "tags": ["MCP"],
+        "summary": "Acme Docs MCP",
+        "description": "MCP endpoint for searching Acme's documentation.",
+        "operationId": "acmeDocsMcp",
+        "x-mcp-server": {
+          "name": "acme-docs",
+          "version": "1.0.0",
+          "tools": [
+            {
+              "name": "search_docs",
+              "description": "Search the documentation"
+            }
+          ]
+        },
+        "responses": {
+          "200": {
+            "description": "MCP response"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Reference the spec from your Dev Portal config (see
+[API Reference](./zudoku/configuration/api-reference.md) for the full `apis`
+configuration):
+
+```tsx title="zudoku.config.tsx"
+import type { ZudokuConfig } from "zudoku";
+
+const config: ZudokuConfig = {
+  apis: [
+    {
+      type: "file",
+      input: "./mcp-api.json",
+      path: "mcp",
+    },
+  ],
+  navigation: [
+    {
+      type: "link",
+      label: "MCP Server",
+      to: "/mcp",
+      icon: "bot",
+    },
+  ],
+};
+
+export default config;
+```
+
+## Generated UI
+
+When the Dev Portal detects `x-mcp-server` on an operation, the page renders:
+
+- **MCP Endpoint card** — the full URL with a copy button.
+- **AI Tool Configuration** tabs with setup instructions for:
+  - **Claude** — add via the Connectors UI or the `claude mcp add` CLI command.
+  - **ChatGPT** — app setup via Settings → Apps → Advanced Settings.
+  - **Cursor** — `mcp.json` configuration (global or project-level).
+  - **VS Code** — `.vscode/mcp.json` with native HTTP transport for GitHub
+    Copilot.
+  - **Generic** — standard `mcp.json` format compatible with most MCP clients.
+
+The standard method badge, request body, parameters, and sidecar panels are
+hidden for MCP endpoints because they use a different interaction model.
+
+## Related
+
+- [`x-mcp-server` extension reference](./zudoku/openapi-extensions/x-mcp-server.md)
+  — the underlying OpenAPI extension.
+- [MCP Server Handler](/docs/handlers/mcp-server.mdx) — build an MCP server on
+  Zuplo (and skip this guide entirely).
+- [MCP Server overview](/docs/mcp-server/introduction.mdx) — concepts,
+  capabilities, and the Zuplo-native build path.

--- a/scripts/update-zudoku-docs.mts
+++ b/scripts/update-zudoku-docs.mts
@@ -69,6 +69,14 @@ async function updateDocs(dir: string) {
           .replace(
             /\[([^\]]*)\]\(\/dev-portal\/zudoku\/theme-playground\)/g,
             "[$1](https://zudoku.dev/docs/theme-playground)",
+          )
+          // Redirect the upstream "Documenting MCP Servers" guide link to the
+          // Zuplo-specific guide. The upstream guide is excluded (zuplo: false)
+          // because Zuplo's mcpServerHandler adds x-mcp-server automatically;
+          // the Zuplo version reframes the guide for external/proxied servers.
+          .replace(
+            /\[([^\]]*)\]\(\/dev-portal\/zudoku\/guides\/mcp-servers\)/g,
+            "[$1](/docs/dev-portal/documenting-mcp-servers)",
           );
 
         // // Insert text after frontmatter

--- a/sidebar.ts
+++ b/sidebar.ts
@@ -279,6 +279,7 @@ const devPortalItems: Navigation = [
             ...item.items,
             "dev-portal/auth-provider-api-identities",
             "dev-portal/dev-portal-create-consumer-on-auth",
+            "dev-portal/documenting-mcp-servers",
             "articles/rick-and-morty-api-developer-portal-example",
           ],
         };


### PR DESCRIPTION
## Summary

- Adds a Zuplo-framed **Documenting MCP Servers** guide at `docs/dev-portal/documenting-mcp-servers.mdx`, scoped to external/proxied MCP servers — the upstream Zudoku guide is excluded (`zuplo: false`) because Zuplo's `mcpServerHandler` adds `x-mcp-server` to OpenAPI specs automatically, and that conflict was confusing.
- Wires the dangling link in the auto-pulled `x-mcp-server.md` to the new page via a rewrite in `scripts/update-zudoku-docs.mts` (same pattern as the existing `theme-playground` redirect).
- Adds the new doc to the Dev Portal **Guides** sidebar in `sidebar.ts`.

## Why

The upstream Zudoku "Documenting MCP Servers" guide ships as part of the tarball but is filtered out by the postinstall sync (it has `zuplo: false`). The reason: it documents the `x-mcp-server` extension as something users add manually, but Zuplo's MCP handler does that for you — readers building with the handler shouldn't need to touch it. However, the auto-pulled `openapi-extensions/x-mcp-server.md` still linked to the excluded guide, producing a 404.

The new Zuplo guide opens with a `:::tip` that points handler users straight to the [MCP Server overview](docs/mcp-server/introduction.mdx), then frames the rest of the page for the cases where `x-mcp-server` *does* matter: third-party MCP servers proxied through a Zuplo route, hand-authored OpenAPI specs, and mixed catalogs.

## Notes for reviewer

- The post-rewrite link in the regenerated `docs/dev-portal/zudoku/openapi-extensions/x-mcp-server.md` (gitignored) now reads `[Documenting MCP Servers guide](/docs/dev-portal/documenting-mcp-servers).` — verified locally after `pnpm install` ran the sync.
- Linked files referenced in the new guide all exist: `docs/handlers/mcp-server.mdx`, `docs/mcp-server/introduction.mdx`, `docs/handlers/url-forward.mdx`, `docs/handlers/custom-handler.mdx`.
- Scope is intentionally narrow: this PR doesn't touch the existing `docs/mcp-server/` content or the `mcpServerHandler` docs.

## Test plan

- [x] `pnpm install` (runs `zudoku:get` + sync script; confirmed rewrite fires and the upstream guide is still removed)
- [x] `pnpm run typecheck`
- [x] `pnpm run lint:admonitions`
- [x] `pnpm exec prettier --check` on changed files
- [ ] Reviewer: spot-check the rendered page in the Dev Portal sidebar under **Guides** and confirm the link from the `x-mcp-server` extension page lands on it

🤖 Generated with [Claude Code](https://claude.com/claude-code)