### PR TITLE
Add AI agent tooling: skills, MCP servers, and docs

### DIFF
--- a/docs/articles/ai-agents.mdx
+++ b/docs/articles/ai-agents.mdx
@@ -1,5 +1,5 @@
 ---
-title: Set up your Zuplo project for AI coding agents
+title: AI Coding Agents
 sidebar_label: AI Coding Agents
 ---
 
@@ -8,9 +8,19 @@ allowing AI coding agents to reference accurate, up-to-date APIs and patterns.
 An `AGENTS.md` file at the root of your project directs agents to these bundled
 docs instead of their training data.
 
+For task-specific playbooks and Zuplo capabilities beyond documentation lookup,
+see:
+
+- [Agent Skills](../build-with-ai/skills.md) — install the official skills from
+  [`zuplo/tools`](https://github.com/zuplo/tools).
+- [Docs MCP Server](../build-with-ai/docs-mcp-server.md) — real-time search and
+  Q&A across the full Zuplo documentation.
+- [Zuplo MCP Server](../build-with-ai/zuplo-mcp-server.md) — manage your Zuplo
+  account programmatically from agents.
+
 ## How it works
 
-When you install `zuplo`, the full Zuplo documentation is bundled at
+Installing `zuplo` bundles the full Zuplo documentation at
 `node_modules/zuplo/docs/`. The bundled docs cover policies, handlers, concepts,
 guides, CLI reference, and more:
 
@@ -38,8 +48,8 @@ Code, Cursor, GitHub Copilot, Windsurf, and others — automatically read
 
 ### New projects
 
-When you create a new project with `create-zuplo-api`, the `AGENTS.md` and
-`CLAUDE.md` files are generated automatically. No additional setup is needed:
+Creating a new project with `create-zuplo-api` generates the `AGENTS.md` and
+`CLAUDE.md` files automatically. No additional setup is needed:
 
 ```bash
 npx create-zuplo-api@latest
@@ -84,86 +94,26 @@ outdated training data.
 You can add your own project-specific instructions to `AGENTS.md` or `CLAUDE.md`
 alongside the Zuplo defaults.
 
-## Install official skills
+## Going further
 
-For a richer experience, install the official
-[Zuplo agent skills](https://github.com/zuplo/tools). Skills provide
-specialized, task-specific guidance that goes beyond general documentation
-lookup — they teach agents how to set up projects, configure policies, write
-handlers, set up monetization, and more.
+Once `AGENTS.md` is in place, layer on the rest of Zuplo's agent tooling:
 
-### What are agent skills?
-
-[Agent skills](https://agentskills.io) are structured instruction files that AI
-coding agents load automatically. Each skill focuses on a specific domain and
-includes step-by-step guidance, code patterns, and references to documentation.
-
-### Available skills
-
-| Skill                   | Description                                                                                                          |
-| ----------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| **zuplo-guide**         | Comprehensive gateway guide — documentation lookup, request pipeline, route/policy configuration, custom handlers.   |
-| **zuplo-project-setup** | Step-by-step new project setup — scaffolding, routes, auth, rate limiting, CORS, env vars, deployment.               |
-| **zuplo-policies**      | Policy configuration — built-in policy catalog, custom code policies, wiring policies to routes.                     |
-| **zuplo-handlers**      | Request handlers — URL forwarding/rewriting, redirects, custom TypeScript handlers, Lambda, WebSockets, MCP servers. |
-| **zuplo-monetization**  | API monetization — meters, plans, Stripe billing, subscriptions, usage tracking.                                     |
-| **zuplo-cli**           | CLI reference — local dev, deployment, env vars, tunnels, OpenAPI tools, project management.                         |
-| **zudoku-guide**        | Comprehensive Zudoku framework guide — setup, configuration, OpenAPI integration, plugins, auth, theming.            |
-
-### Install skills
-
-Install the skills from GitHub:
-
-```bash
-npx skills add zuplo/tools
-```
-
-Or via `.well-known` discovery:
-
-```bash
-npx skills add https://zuplo.com/
-```
-
-After installation, agents automatically load the relevant skills when working
-in your project.
-
-## Optional: Add the MCP server
-
-For search and Q&A across all Zuplo documentation, you can also add the Zuplo
-MCP server. This gives agents the ability to search docs and ask questions in
-real-time.
-
-For **Claude Code**, add to `.claude/settings.json`:
-
-```json title=".claude/settings.json"
-{
-  "mcpServers": {
-    "zuplo-docs": {
-      "type": "http",
-      "url": "https://dev.zuplo.com/mcp/docs"
-    }
-  }
-}
-```
-
-:::tip
-
-The MCP server is optional. The bundled docs in `node_modules/zuplo/docs/`
-provide complete, version-matched documentation without any network requests.
-The MCP server is useful for broader search and Q&A across all Zuplo
-documentation.
-
-:::
+1. [**Install the official skills**](../build-with-ai/skills.md) for
+   task-specific playbooks on project setup, policies, handlers, monetization,
+   and more.
+2. [**Add the Docs MCP server**](../build-with-ai/docs-mcp-server.md) for
+   real-time search and Q&A across the full documentation.
+3. [**Add the Zuplo MCP server**](../build-with-ai/zuplo-mcp-server.md) to let
+   agents drive your Zuplo account — deploy, manage API keys, inspect logs, and
+   more.
 
 ## Summary
 
-There are three ways to give AI coding agents access to Zuplo documentation,
-listed in priority order:
+The recommended setup, in priority order:
 
-1. **Bundled docs** (recommended) — always available at
-   `node_modules/zuplo/docs/`, version-matched, no setup required beyond
-   `AGENTS.md`
-2. **Agent skills** — install from [zuplo/tools](https://github.com/zuplo/tools)
-   for task-specific guidance on project setup, policies, handlers,
-   monetization, and more
-3. **MCP server** — add the Zuplo docs MCP server for real-time search and Q&A
+1. **Bundled docs** — always available at `node_modules/zuplo/docs/`,
+   version-matched, no setup required beyond `AGENTS.md`.
+2. **[Agent skills](../build-with-ai/skills.md)** — task-specific guidance from
+   [`zuplo/tools`](https://github.com/zuplo/tools).
+3. **[MCP servers](../build-with-ai/overview.md)** — real-time docs search and
+   programmatic gateway management.

--- a/docs/build-with-ai/docs-mcp-server.mdx
+++ b/docs/build-with-ai/docs-mcp-server.mdx
@@ -1,0 +1,97 @@
+---
+title: Docs MCP Server
+sidebar_label: Docs MCP Server
+---
+
+The Zuplo Docs MCP server exposes the full Zuplo documentation through the
+[Model Context Protocol](https://modelcontextprotocol.io). AI agents can search,
+ask questions, and pull in accurate, up-to-date answers without leaving the
+editor.
+
+**Endpoint:** `https://dev.zuplo.com/mcp/docs`
+
+This server is public — no authentication required.
+
+## What it does
+
+The Docs MCP server provides two tools:
+
+| Tool                       | Purpose                                                                                                       |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `search-zuplo-docs`        | Semantic search across all Zuplo documentation. Useful for finding pages on policies, handlers, and concepts. |
+| `ask-question-about-zuplo` | Ask a natural-language question. The server returns a synthesized answer grounded in the docs.                |
+
+## Add it to your client
+
+### Claude Code
+
+Add the server to `.claude/settings.json`:
+
+```json title=".claude/settings.json"
+{
+  "mcpServers": {
+    "zuplo-docs": {
+      "type": "http",
+      "url": "https://dev.zuplo.com/mcp/docs"
+    }
+  }
+}
+```
+
+### Cursor
+
+Add the server to `.cursor/mcp.json`:
+
+```json title=".cursor/mcp.json"
+{
+  "mcpServers": {
+    "zuplo-docs": {
+      "url": "https://dev.zuplo.com/mcp/docs"
+    }
+  }
+}
+```
+
+### VS Code (GitHub Copilot)
+
+Add the server to `.vscode/mcp.json`:
+
+```json title=".vscode/mcp.json"
+{
+  "servers": {
+    "zuplo-docs": {
+      "type": "http",
+      "url": "https://dev.zuplo.com/mcp/docs"
+    }
+  }
+}
+```
+
+### Other clients
+
+Most MCP-compatible clients accept a streamable HTTP endpoint. Point them at
+`https://dev.zuplo.com/mcp/docs` — no headers or credentials needed.
+
+## When to use it
+
+The Docs MCP server is most useful when:
+
+- You want answers grounded in the **latest** docs, even when the agent's
+  training data is stale.
+- You're working outside a Zuplo project, so the bundled
+  `node_modules/zuplo/docs/` isn't available.
+- You want a one-question lookup ("How do I configure the rate-limit policy?")
+  without manually opening the docs site.
+
+For project-local work, prefer the
+[bundled docs in `node_modules/zuplo/docs/`](../articles/ai-agents.md) — they
+match your installed Zuplo version and don't require a network round-trip.
+
+## Related
+
+- [AI Coding Agents](../articles/ai-agents.md) — how to set up `AGENTS.md` and
+  bundled docs.
+- [Agent Skills](./skills.md) — task-specific guidance that complements the docs
+  MCP server.
+- [Zuplo MCP Server](./zuplo-mcp-server.md) — manage your Zuplo account
+  programmatically from agents.

--- a/docs/build-with-ai/overview.mdx
+++ b/docs/build-with-ai/overview.mdx
@@ -1,0 +1,68 @@
+---
+title: Build with AI
+sidebar_label: Overview
+---
+
+Zuplo gives AI coding agents — Claude Code, Cursor, GitHub Copilot, Codex,
+Windsurf, and others — first-class support for building, configuring, and
+managing your API gateway. This section covers the tools, skills, and Model
+Context Protocol (MCP) servers that make Zuplo agent-ready.
+
+## What's included
+
+| Tool                                         | Purpose                                                                                                                                                     |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [AI Coding Agents](../articles/ai-agents.md) | Configure `AGENTS.md` and use version-matched docs bundled with the `zuplo` npm package.                                                                    |
+| [Agent Skills](./skills.md)                  | Install the official Zuplo and Zudoku skills from [`zuplo/tools`](https://github.com/zuplo/tools) for task-specific agent guidance.                         |
+| [Docs MCP Server](./docs-mcp-server.md)      | Connect agents to `https://dev.zuplo.com/mcp/docs` for real-time search and Q&A across Zuplo documentation.                                                 |
+| [Zuplo MCP Server](./zuplo-mcp-server.md)    | Connect agents to `https://dev.zuplo.com/mcp` to manage accounts, deployments, API keys, custom domains, tunnels, and more through the Zuplo Developer API. |
+
+## How the pieces fit together
+
+The pieces are complementary — they work best when using them together:
+
+1. **`AGENTS.md` and bundled docs** keep agents grounded in your project's
+   installed Zuplo version. No network calls required.
+2. **Skills** add task-specific playbooks for common workflows (project setup,
+   policies, monetization, CLI usage).
+3. **MCP servers** give agents live capabilities — searching the latest docs and
+   driving your Zuplo account programmatically.
+
+:::tip
+
+If you're starting fresh, run `npx create-zuplo-api@latest` — it scaffolds
+`AGENTS.md` and `CLAUDE.md` for you. Then install the skills and add the MCP
+servers as needed.
+
+:::
+
+## Quick start
+
+Add both MCP servers to Claude Code by editing `.claude/settings.json`:
+
+```json title=".claude/settings.json"
+{
+  "mcpServers": {
+    "zuplo-docs": {
+      "type": "http",
+      "url": "https://dev.zuplo.com/mcp/docs"
+    },
+    "zuplo": {
+      "type": "http",
+      "url": "https://dev.zuplo.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${ZUPLO_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+Install the official skills:
+
+```bash
+npx skills add zuplo/tools
+```
+
+See the linked pages above for client-specific setup, authentication, and the
+full list of available tools.

--- a/docs/build-with-ai/skills.mdx
+++ b/docs/build-with-ai/skills.mdx
@@ -1,0 +1,131 @@
+---
+title: Agent Skills
+sidebar_label: Agent Skills
+---
+
+[Agent skills](https://agentskills.io) are structured instruction files that AI
+coding agents load automatically. Each skill focuses on a specific domain and
+includes step-by-step guidance, code patterns, and references to the relevant
+documentation.
+
+The official Zuplo skills live in
+[`zuplo/tools`](https://github.com/zuplo/tools). They cover gateway
+configuration, monetization, the CLI, and the Zudoku developer portal — so
+agents have task-specific playbooks instead of relying on training data that may
+be out of date.
+
+## Available skills
+
+### Zuplo
+
+| Skill                  | Description                                                                                                                                                                      |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **zuplo-guide**        | Comprehensive gateway guide — documentation lookup, request pipeline, route and policy configuration, custom handlers, and deployment. Start here for general Zuplo development. |
+| **zuplo-monetization** | API monetization — meters, plans, Stripe billing, subscriptions, usage tracking, private plans, and tax collection.                                                              |
+| **zuplo-cli**          | CLI reference — local development, deployment, environment variables, tunnels, OpenAPI tools, mTLS, and project management.                                                      |
+
+### Zudoku (Developer Portal)
+
+| Skill            | Description                                                                                                                                |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| **zudoku-guide** | Comprehensive Zudoku framework guide — setup, configuration, OpenAPI integration, plugins, auth, theming, troubleshooting, and migrations. |
+
+## Installation
+
+### Claude Code
+
+Register the repo as a plugin marketplace, then install the skills:
+
+```bash
+/plugin marketplace add zuplo/tools
+/plugin install zuplo-skills@zuplo-tools
+/plugin install zudoku-skills@zuplo-tools
+```
+
+### Cursor
+
+Open **Cursor Settings → Rules → Add Rule → Remote Rule (GitHub)** and enter
+`https://github.com/zuplo/tools`. Or copy the skill directories into your
+project:
+
+```txt
+.cursor/skills/
+├── zuplo-guide/SKILL.md
+├── zuplo-monetization/SKILL.md
+├── zuplo-cli/SKILL.md
+└── zudoku-guide/SKILL.md
+```
+
+Skills placed in `.cursor/skills/`, `.agents/skills/`, or `~/.cursor/skills/`
+are auto-discovered.
+
+### GitHub Copilot and VS Code
+
+Copilot reads `AGENTS.md` at the repo root automatically. Add the Zuplo
+`AGENTS.md` to your project for project-level context:
+
+```bash
+curl -o AGENTS.md https://raw.githubusercontent.com/zuplo/tools/main/AGENTS.md
+```
+
+You can also use the `/create-skill` command in Copilot chat and reference the
+skills in [`zuplo/tools`](https://github.com/zuplo/tools) as a starting point.
+
+### Codex (OpenAI)
+
+Codex reads `AGENTS.md` at the repo root. Add the Zuplo `AGENTS.md` to your
+project so Codex picks up project-level context.
+
+### Using the `skills` CLI
+
+The cross-client
+[`skills` CLI](https://github.com/cloudflare/agent-skills-discovery-rfc)
+installs skills directly:
+
+```bash
+npx skills add zuplo/tools
+```
+
+Or via `.well-known` discovery:
+
+```bash
+npx skills add https://zuplo.com/
+npx skills add https://zudoku.dev/
+```
+
+### Manual install
+
+```bash
+git clone https://github.com/zuplo/tools.git
+```
+
+Then copy the skill directories you need into your project's skills directory.
+
+## How skills find documentation
+
+All Zuplo skills look up documentation in this order:
+
+1. **Local docs from `node_modules/zuplo/docs/`** (preferred). The `zuplo` npm
+   package ships with the full Zuplo documentation, version-matched to your
+   installed Zuplo version. See [AI Coding Agents](../articles/ai-agents.md) for
+   setup details.
+2. **The [Zuplo Docs MCP server](./docs-mcp-server.md)** for search and Q&A
+   across the full documentation.
+3. **Fetch docs via URL** as a fallback (`https://zuplo.com/docs/`).
+
+:::tip
+
+Combine the skills with the [Zuplo MCP server](./zuplo-mcp-server.md) to let
+your agent both write the code and operate the gateway — for example, scaffold a
+route locally, then deploy and inspect logs without leaving the session.
+
+:::
+
+## Contributing
+
+The skills are MIT-licensed. To improve them:
+
+1. Fork [`zuplo/tools`](https://github.com/zuplo/tools).
+2. Update the relevant `SKILL.md` file.
+3. Test with your own development workflow.
+4. Open a pull request.

--- a/docs/build-with-ai/zuplo-mcp-server.mdx
+++ b/docs/build-with-ai/zuplo-mcp-server.mdx
@@ -1,0 +1,175 @@
+---
+title: Zuplo MCP Server
+sidebar_label: Zuplo MCP Server
+---
+
+The Zuplo MCP server exposes the [Zuplo Developer API](https://dev.zuplo.com)
+through the [Model Context Protocol](https://modelcontextprotocol.io). Agents
+can manage accounts, deployments, API keys, custom domains, tunnels, audit logs,
+and more — all in a single, authenticated session.
+
+**Endpoint:** `https://dev.zuplo.com/mcp`
+
+Unlike the [Docs MCP server](./docs-mcp-server.md), this server is authenticated
+and performs **real operations against your Zuplo account**. Use it carefully.
+
+:::caution
+
+Connecting an agent to this server gives it the same permissions as the API key
+you authenticate with. Scope the API key tightly (project, environment,
+permissions) and treat the token like any other production credential.
+
+:::
+
+## Authentication
+
+Authenticate using a [Zuplo API key](../articles/accounts/zuplo-api-keys.md).
+Create one in the Zuplo Portal under
+[**Account Settings → API Keys**](https://portal.zuplo.com/+/account/settings/api-keys),
+then pass it as a bearer token:
+
+```http
+Authorization: Bearer <ZUPLO_API_KEY>
+```
+
+The API key determines which accounts, projects, and operations the agent can
+access — only the resources granted to the key are exposed as MCP tools at
+runtime.
+
+## What it does
+
+The server exposes the Developer API surface as MCP tools. Capabilities include:
+
+| Area                  | What agents can do                                                                         |
+| --------------------- | ------------------------------------------------------------------------------------------ |
+| **Accounts**          | List accounts and identify the caller (`WhoAmI`).                                          |
+| **Projects**          | List projects and environments in an account.                                              |
+| **Deployments**       | List, read, redeploy, and delete deployments. Upload sources and check deployment status.  |
+| **API Key Buckets**   | Create, list, read, update, and delete API key buckets.                                    |
+| **API Key Consumers** | Create, list, read, update, delete, and roll keys for consumers. Manage consumer managers. |
+| **API Keys**          | Create (single or bulk), list, read, update, and delete keys for a consumer.               |
+| **Custom Domains**    | Create, list, update, and delete custom domains.                                           |
+| **Client mTLS CAs**   | Create, list, update, and delete client mTLS CA certificates.                              |
+| **Tunnels**           | Create, list, read, update, and delete tunnels. Configure and inspect tunneled services.   |
+| **Variables**         | Create and update environment variables on a project branch.                               |
+| **Audit Logs**        | Query audit logs with filtering and pagination.                                            |
+| **Analytics**         | Get recent calls and request statistics by status code for a deployment.                   |
+
+The full tool catalog is generated from the Developer API's OpenAPI spec, so new
+endpoints become available as MCP tools automatically when the API ships them.
+
+## Add it to your client
+
+### Claude Code
+
+Add the server to `.claude/settings.json`. Store the API key in an environment
+variable rather than committing it:
+
+```json title=".claude/settings.json"
+{
+  "mcpServers": {
+    "zuplo": {
+      "type": "http",
+      "url": "https://dev.zuplo.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${ZUPLO_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+Then export the key in your shell:
+
+```bash
+export ZUPLO_API_KEY="zpka_..."
+```
+
+### Cursor
+
+Add the server to `.cursor/mcp.json`:
+
+```json title=".cursor/mcp.json"
+{
+  "mcpServers": {
+    "zuplo": {
+      "url": "https://dev.zuplo.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${ZUPLO_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+### VS Code (GitHub Copilot)
+
+Add the server to `.vscode/mcp.json`. VS Code prompts for the API key on first
+use:
+
+```json title=".vscode/mcp.json"
+{
+  "inputs": [
+    {
+      "id": "zuplo-api-key",
+      "type": "promptString",
+      "description": "Zuplo API key",
+      "password": true
+    }
+  ],
+  "servers": {
+    "zuplo": {
+      "type": "http",
+      "url": "https://dev.zuplo.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${input:zuplo-api-key}"
+      }
+    }
+  }
+}
+```
+
+### Other clients
+
+Any MCP-compatible client that supports streamable HTTP and custom headers
+works. Send the API key in the `Authorization` header as a bearer token.
+
+## Example workflows
+
+Once connected, ask the agent to drive Zuplo through natural-language prompts:
+
+- _"List all deployments in the `production` environment of project `my-api`."_
+- _"Create a new API key consumer named `acme-corp` and generate a key that
+  expires in 30 days."_
+- _"Roll all API keys for consumer `legacy-client` and set a 7-day expiration on
+  the old key."_
+- _"Show me the request stats by status code for the latest deployment over the
+  last 24 hours."_
+- _"Add `api.example.com` as a custom domain on the `production` environment."_
+- _"Set the environment variable `STRIPE_API_KEY` on the `main` branch."_
+
+## Security best practices
+
+1. **Use short-lived, narrowly-scoped API keys.** Create a dedicated key per
+   agent session or project; don't reuse a single all-powerful key.
+2. **Restrict permissions.** Limit the key to the smallest set of projects,
+   environments, and permissions the agent needs. See
+   [API Keys](../articles/accounts/zuplo-api-keys.md) for the full permissions
+   model.
+3. **Never commit keys.** Store them in environment variables or a secret
+   manager — not in `.claude/settings.json` or `.cursor/mcp.json`.
+4. **Audit usage.** Use the `ListAuditLogsService` tool or the
+   [Audit Logs](../articles/accounts/audit-logs.md) view in the Portal to review
+   what the agent did.
+5. **Revoke when done.** Delete the API key from the Portal as soon as the
+   session is over.
+
+## Related
+
+- [Zuplo Developer API](https://dev.zuplo.com) — the underlying REST API.
+- [Zuplo API Keys](../articles/accounts/zuplo-api-keys.md) — create and manage
+  the API keys used to authenticate this MCP server.
+- [Docs MCP Server](./docs-mcp-server.md) — pair this with the docs server so
+  agents can both read docs and operate the gateway.
+- [Audit Logs](../articles/accounts/audit-logs.md) — review changes made by an
+  agent.

--- a/sidebar.ts
+++ b/sidebar.ts
@@ -359,7 +359,6 @@ export const documentation: Navigation = [
     label: "Development",
     icon: "wrench",
     items: [
-      "articles/ai-agents",
       "articles/cors",
       "articles/environment-variables",
       "articles/branch-based-deployments",
@@ -475,6 +474,18 @@ export const documentation: Navigation = [
           "articles/manual-mcp-oauth-testing",
         ],
       },
+    ],
+  },
+  {
+    type: "category",
+    label: "Build with AI",
+    icon: "sparkles",
+    items: [
+      "build-with-ai/overview",
+      "articles/ai-agents",
+      "build-with-ai/skills",
+      "build-with-ai/docs-mcp-server",
+      "build-with-ai/zuplo-mcp-server",
     ],
   },
   {


### PR DESCRIPTION
Introduces comprehensive AI agent support for Zuplo by adding documentation, guides, and infrastructure for AI coding agents to build, configure, and manage API gateways.

## Summary

This change establishes Zuplo's AI agent ecosystem by documenting three complementary tools: Agent Skills (task-specific playbooks), the Docs MCP Server (real-time documentation search), and the Developer API MCP Server (programmatic account management). It reorganizes the documentation structure to create a dedicated "Build with AI" section and updates the AI Coding Agents guide to reference the new resources.

## Key changes

- **New "Build with AI" section** in documentation with four pages:
  - `overview.mdx` — introduction to all AI agent tools and how they work together
  - `skills.mdx` — guide to installing and using official Zuplo and Zudoku agent skills from `zuplo/tools`
  - `docs-mcp-server.mdx` — setup and usage of the public Docs MCP server at `https://dev.zuplo.com/mcp/docs`
  - `developer-api-mcp-server.mdx` — setup, authentication, and security best practices for the authenticated Developer API MCP server at `https://dev.zuplo.com/mcp`

- **Reorganized AI Coding Agents guide** (`articles/ai-agents.mdx`):
  - Shortened title and refocused on bundled docs setup
  - Removed duplicated skill installation instructions (now in dedicated skills page)
  - Removed duplicated MCP server setup (now in dedicated MCP pages)
  - Added cross-references to the new "Build with AI" resources
  - Restructured "Going further" section to guide users through the full tooling stack

- **Updated sidebar navigation** (`sidebar.ts`):
  - Moved `ai-agents` from "Development" section to new "Build with AI" category
  - Added new category with icon "sparkles" containing all AI-related documentation

- **CLI reference updates** (`sidebar.cli.json`):
  - Added missing CLI commands: `bucket-list`, `ca-certificate-*` (create, delete, describe, list, update), and `logout`

- **Added policy icons** (SVG assets):
  - `akamai-firewall-for-ai-inbound.svg`
  - `akamai-firewall-for-ai-outbound.svg`

## Implementation details

- All new documentation follows the repository's style guidelines (American English, present tense, Microsoft Writing Style Guide)
- MCP server setup instructions are tailored per client (Claude Code, Cursor, VS Code/GitHub Copilot, generic HTTP)
- Security best practices are emphasized for the authenticated Developer API MCP server
- Cross-references use relative paths with `.md`/`.mdx` extensions as per conventions
- Portal shortcut links use the `/+/` format for account and project-level navigation

https://claude.ai/code/session_01C7ezNV44g8k15ELTCZcpLS