### PR TITLE
chore: add .worktreeinclude and consolidate .claude/ gitignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,14 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
-# Claude Code
-.claude/worktrees
+# Claude Code: ignore everything in .claude/ except tracked
+# config/commands/skills/agents/hooks. Add new tracked paths here
+# with a leading "!".
+.claude/*
+!.claude/settings.json
+!.claude/commands/
+!.claude/skills/
+!.claude/agents/
+!.claude/hooks/
 
 # dependencies
 /node_modules

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,3 +1,2 @@
 .env
 .env.local
-.env.zuplo

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+.env
+.env.local
+.env.zuplo


### PR DESCRIPTION
## Summary
- Adds `.worktreeinclude` so Claude Code copies `.env`, `.env.local`, and `.env.zuplo` into new git worktrees automatically — no more re-injecting env files each time.
- Consolidates `.claude/` gitignore rules: shared agent config (`settings.json`, `commands/`, `skills/`, `agents/`, `hooks/`) is tracked; local-only files (worktrees/, settings.local.json, etc.) are ignored.

Part of a workspace-wide rollout to standardize how repos are configured for Claude Code agents and worktrees.

## Test plan
- [ ] Create a worktree (`claude worktree new`) and verify env files are copied in
- [ ] `git status` stays clean when adding new local-only files under `.claude/`