### PR TITLE
docs(monetization): fix in-advance billing examples and clarify FAQs

### DIFF
--- a/docs/articles/monetization/plan-examples.mdx
+++ b/docs/articles/monetization/plan-examples.mdx
@@ -191,6 +191,17 @@ curl \
       "duration": null,
       "rateCards": [
         {
+          "type": "flat_fee",
+          "key": "subscription_fee",
+          "name": "Starter Plan Subscription",
+          "billingCadence": "P1M",
+          "price": {
+            "type": "flat",
+            "amount": "9.99",
+            "paymentTerm": "in_advance"
+          }
+        },
+        {
           "type": "usage_based",
           "key": "api_requests",
           "name": "API Requests",
@@ -208,7 +219,7 @@ curl \
             "tiers": [
               {
                 "upToAmount": "1000",
-                "flatPrice": { "type": "flat", "amount": "9.99" },
+                "flatPrice": { "type": "flat", "amount": "0.00" },
                 "unitPrice": null
               },
               {
@@ -227,10 +238,16 @@ EOF
 
 **What changed:**
 
-- Changed the rate card from `flat_fee` to `usage_based`
-- Changed `isSoftLimit` to `true` - requests continue after 1,000
-- Combined base fee and overage into tiered pricing: first 1,000 cost $9.99
-  flat, then $0.01 per additional request
+- Split the default phase into two rate cards: a billing-only `flat_fee` rate
+  card (no `featureKey`, `paymentTerm: "in_advance"`) that collects the $9.99
+  subscription fee at the start of each billing period, and a `usage_based`
+  rate card that grants the entitlement and prices overage
+- Tier 1's `flatPrice` is set to $0 because the $9.99 is now collected by the
+  separate `flat_fee` rate card — leaving it at $9.99 here would double-charge
+  the customer in arrears at the end of the period
+- Changed `isSoftLimit` to `true` so requests continue past 1,000 and tier 2
+  applies — overage is billed at $0.01 per request above the allowance, in
+  arrears at the end of the period
 
 **Example billing:**
 
@@ -306,6 +323,17 @@ curl \
       "duration": null,
       "rateCards": [
         {
+          "type": "flat_fee",
+          "key": "subscription_fee",
+          "name": "Starter Plan Subscription",
+          "billingCadence": "P1M",
+          "price": {
+            "type": "flat",
+            "amount": "9.99",
+            "paymentTerm": "in_advance"
+          }
+        },
+        {
           "type": "usage_based",
           "key": "api_requests",
           "name": "API Requests",
@@ -323,7 +351,7 @@ curl \
             "tiers": [
               {
                 "upToAmount": "1000",
-                "flatPrice": { "type": "flat", "amount": "9.99" },
+                "flatPrice": { "type": "flat", "amount": "0.00" },
                 "unitPrice": null
               },
               {

--- a/docs/articles/monetization/plan-examples.mdx
+++ b/docs/articles/monetization/plan-examples.mdx
@@ -240,8 +240,8 @@ EOF
 
 - Split the default phase into two rate cards: a billing-only `flat_fee` rate
   card (no `featureKey`, `paymentTerm: "in_advance"`) that collects the $9.99
-  subscription fee at the start of each billing period, and a `usage_based`
-  rate card that grants the entitlement and prices overage
+  subscription fee at the start of each billing period, and a `usage_based` rate
+  card that grants the entitlement and prices overage
 - Tier 1's `flatPrice` is set to $0 because the $9.99 is now collected by the
   separate `flat_fee` rate card — leaving it at $9.99 here would double-charge
   the customer in arrears at the end of the period

--- a/docs/articles/monetization/troubleshooting.md
+++ b/docs/articles/monetization/troubleshooting.md
@@ -195,30 +195,46 @@ products.
 
 ### What happens if Stripe is down?
 
-Zuplo caches subscription and quota state locally. If Stripe is temporarily
-unavailable, existing customers continue to have access based on their cached
-subscription state. New subscriptions and plan changes require Stripe to be
-available.
+Zuplo's API request path doesn't go through Stripe. The runtime validates each
+request against Zuplo's own subscription store, so existing customers keep
+access while Stripe is unavailable. New paid subscriptions and billing-affecting
+plan changes do need Stripe and have to wait; free plans skip Stripe Checkout
+entirely and still work. If Stripe misses scheduled payments during the outage,
+the [grace period](./monetization-policy.md#subscription-and-payment-validation)
+(default 3 days) absorbs them once Stripe recovers and reports the failures.
 
 ### Can I use currencies other than USD?
 
 Yes. Plans support any ISO 4217 currency code. Set the `currency` field when
 creating a plan. You can offer the same plan in multiple currencies by creating
-separate plan objects (e.g., `pro-usd` and `pro-eur`).
+separate plan objects (e.g., `pro_usd` and `pro_eur`).
 
 ### How are overages calculated?
 
-Overages are modeled using graduated tiered pricing. The first tier covers the
-included allowance at a flat price, and subsequent tiers charge per-unit for
-usage beyond the allowance. See [Pricing Models](./pricing-models.mdx) for
-details.
+Overage uses graduated tiered pricing on a `usage_based` rate card. Every tier
+has two price slots, `flatPrice` and `unitPrice` — either or both can be set
+(each may be 0), and a tier charges its flat price plus its per-unit price
+times the units consumed inside the tier. All tier-based charges are billed in
+arrears at the end of the billing cycle. The entitlement must set
+`isSoftLimit: true`, otherwise the policy returns 403 at the quota line and
+there's no overage to bill.
+
+For example, tier 1 with `flatPrice: $499` covers the first 1M requests; tier 2
+with `unitPrice: $0.0005` covers each request after. A customer who used 1.2M
+requests invoices $499 + (200,000 × $0.0005) = $599 at the end of the period.
+
+If you need a fixed fee billed at the **start** of the cycle instead, add a
+separate billing-only rate card alongside the usage-based one (no `featureKey`,
+`paymentTerm: "in_advance"`) — see
+[Base fee in advance](./billing-models.md#example-base-fee-in-advance). For the
+full rate card shape, see
+[Included Usage with Overage](./pricing-models.mdx#included-usage-with-overage).
 
 ### Can I set spending limits for pay-as-you-go customers?
 
 You can set a hard entitlement limit that acts as a spending cap (e.g., max
 100,000 requests regardless of willingness to pay). Alternatively, use a custom
-policy to check current usage against a configurable limit, or set up Stripe
-billing alerts to notify customers approaching a threshold.
+policy to check current usage against a configurable limit.
 
 ### Do meters count retried requests?
 

--- a/docs/articles/monetization/troubleshooting.md
+++ b/docs/articles/monetization/troubleshooting.md
@@ -26,8 +26,8 @@ announced.
    access is blocked.
 
    ```bash
-   curl https://dev.zuplo.com/v3/metering/{bucketId}/customers/{CUSTOMER_ID}/subscriptions \
-     -H "Authorization: Bearer {API_KEY}"
+   curl https://dev.zuplo.com/v3/metering/${BUCKET_ID}/customers/${CUSTOMER_ID}/subscriptions \
+     -H "Authorization: Bearer ${API_KEY}"
    ```
 
    Fix: Either resolve the payment issue in Stripe, or adjust the grace period.
@@ -142,27 +142,29 @@ entitlements don't change.
 
 ```bash
 # List subscriptions for a customer
-curl https://dev.zuplo.com/v3/metering/{bucketId}/customers/{CUSTOMER_ID}/subscriptions \
-  -H "Authorization: Bearer {API_KEY}"
+curl https://dev.zuplo.com/v3/metering/${BUCKET_ID}/customers/${CUSTOMER_ID}/subscriptions \
+  -H "Authorization: Bearer ${API_KEY}"
 
 # Check subscription access and entitlements
-curl https://dev.zuplo.com/v3/metering/{bucketId}/subscriptions/{subscriptionId}/access \
-  -H "Authorization: Bearer {API_KEY}"
+curl https://dev.zuplo.com/v3/metering/${BUCKET_ID}/subscriptions/${SUBSCRIPTION_ID}/access \
+  -H "Authorization: Bearer ${API_KEY}"
 ```
 
 ### Check meter usage
 
 ```bash
 # Query meter usage for the current month
-curl -X POST https://dev.zuplo.com/v3/metering/{bucketId}/meters/{meterIdOrSlug}/query \
-  -H "Authorization: Bearer {API_KEY}" \
+curl -X POST https://dev.zuplo.com/v3/metering/${BUCKET_ID}/meters/${METER_ID_OR_SLUG}/query \
+  -H "Authorization: Bearer ${API_KEY}" \
   -H "Content-Type: application/json" \
-  -d '{
-    "filterSubscription": ["{SUBSCRIPTION_ID}"],
-    "from": "2026-03-01T00:00:00Z",
-    "to": "2026-03-31T23:59:59Z",
-    "windowSize": "DAY"
-  }'
+  -d @- <<EOF
+{
+  "filterSubscription": ["${SUBSCRIPTION_ID}"],
+  "from": "2026-03-01T00:00:00Z",
+  "to": "2026-12-31T23:59:59Z",
+  "windowSize": "DAY"
+}
+EOF
 ```
 
 ### Test with cURL
@@ -171,7 +173,7 @@ Verify the full flow manually:
 
 ```bash
 # Make a request to a monetized endpoint
-curl -v -H "Authorization: Bearer {CUSTOMER_API_KEY}" \
+curl -v -H "Authorization: Bearer ${CUSTOMER_API_KEY}" \
   https://your-api.zuplo.dev/api/v1/resource
 
 # Check the response status and body for error details
@@ -213,11 +215,11 @@ separate plan objects (e.g., `pro_usd` and `pro_eur`).
 
 Overage uses graduated tiered pricing on a `usage_based` rate card. Every tier
 has two price slots, `flatPrice` and `unitPrice` — either or both can be set
-(each may be 0), and a tier charges its flat price plus its per-unit price
-times the units consumed inside the tier. All tier-based charges are billed in
-arrears at the end of the billing cycle. The entitlement must set
-`isSoftLimit: true`, otherwise the policy returns 403 at the quota line and
-there's no overage to bill.
+(each may be 0), and a tier charges its flat price plus its per-unit price times
+the units consumed inside the tier. All tier-based charges are billed in arrears
+at the end of the billing cycle. The entitlement must set `isSoftLimit: true`,
+otherwise the policy returns 403 at the quota line and there's no overage to
+bill.
 
 For example, tier 1 with `flatPrice: $499` covers the first 1M requests; tier 2
 with `unitPrice: $0.0005` covers each request after. A customer who used 1.2M


### PR DESCRIPTION
## Summary

- **plan-examples §3 and §4:** split the \$9.99 subscription fee out of the `usage_based` rate card's tier-1 `flatPrice` (which charges in arrears) into a separate billing-only `flat_fee` rate card with `paymentTerm: "in_advance"`. Tier-1 `flatPrice` drops to \$0 so the customer isn't double-charged. Customer totals per usage level are unchanged; only timing (start-of-cycle vs. end-of-cycle) and invoice presentation (separate `subscription_fee` line vs. buried in the tiered usage line) change.
- **troubleshooting "What happens if Stripe is down?":** rewrite the answer to attribute outage resilience to the architecture (request validation path doesn't touch Stripe) rather than the 60s runtime cache, which can't carry customers through anything longer than a brief blip. Add grace-period coverage for missed scheduled payments and clarify that free plans still work (they skip Stripe Checkout entirely).
- **troubleshooting "How are overages calculated?":** clarify that every tier has independent `flatPrice` and `unitPrice` slots (either or both, each may be 0); that all tier-based charges bill in arrears at end of cycle; and link to "Base fee in advance" for the start-of-cycle alternative. Add a worked \$599 example using the existing Enterprise numbers from `billing-models.md`.

## Test plan

- [ ] Visual review of `plan-examples.mdx` §3 and §4 — JSON shapes valid, billing table totals at lines 254–259 still correct (totals are unchanged by the split)
- [ ] Visual review of `troubleshooting.md` — FAQ answers read coherently and match tone of neighboring entries
- [ ] Cross-reference links resolve:
  - `./monetization-policy.md#subscription-and-payment-validation`
  - `./billing-models.md#example-base-fee-in-advance`
  - `./pricing-models.mdx#included-usage-with-overage`
- [ ] `pnpm run check` passes for assets and external links
- [ ] `make lint` passes Vale style checks
- [ ] `pnpm run format` produces no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)